### PR TITLE
Allow sequelize.where() as type for FindOptions.where

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2485,7 +2485,7 @@ declare module sequelize {
     /**
      * A hash of attributes to describe your search. See above for examples.
      */
-    where?: WhereOptions | Array<col | and | or | string>;
+    where?: WhereOptions | Array<col | and | or | string> | where;
 
   }
 
@@ -2976,7 +2976,7 @@ declare module sequelize {
     /**
      * A hash of attributes to describe your search. See above for examples.
      */
-    where?: WhereOptions | Array<col | and | or | string>;
+    where?: WhereOptions | Array<col | and | or | string> | where;
 
     /**
      * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with


### PR DESCRIPTION
See http://docs.sequelizejs.com/en/latest/docs/querying/#basics
```js
Post.findAll({
  where: sequelize.where(sequelize.fn('char_length', sequelize.col('status')), 6)
});
```