### PR TITLE
Changed type of return value of `Model<TInstance, TAttributes>.scope`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3565,7 +3565,7 @@ declare module sequelize {
      * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
      *     model will clear the previous scope.
      */
-    scope(options?: string | Array<string> | ScopeOptions | WhereOptions): this;
+    scope(options?: string | Array<string> | ScopeOptions | WhereOptions): Model<TInstance, TAttributes>;
 
     /**
      * Search for multiple instances.


### PR DESCRIPTION
Changed type of return value of `Model<TInstance, TAttributes>.scope` from `this` to `Model<TInstance, TAttributes>`. The following example in https://github.com/Thylossus/sequelize-pull-request-justification-demo/tree/master tries to mimic the example from https://github.com/louy/typed-sequelize/blob/master/README.md.

However, I cannot compile this example due to a type error:

```
index.ts(16,16): error TS2322: Type 'sequelize.Model<Thing, ThingInstance>' is not assignable to type 'sequelize.SequelizeStaticAndInstance.Model<Thing, ThingInstance>'.
  Types of property 'scope' are incompatible.
    Type '(options?: string | string[] | ScopeOptions | WhereOptions) => Model<Thing, ThingInstance>' is not assignable to type '(options?: string | string[] | ScopeOptions | WhereOptions) => this'.
      Type 'Model<Thing, ThingInstance>' is not assignable to type 'this'.
```

This is probably related to https://github.com/Microsoft/TypeScript/issues/5863. Changing the return type of `scope` solves the error for me.
Of course, this is not a sufficient criterion for changing your code, but I believe that isn't working for anyone. Feedback about the correctness of this assumption is very welcome.

Thank you for providing the typings!