### PR TITLE
v4

### DIFF
--- a/4/README.md
+++ b/4/README.md
@@ -1,9 +1,14 @@
-# Typed Sequelize
+# Typed Sequelize@4
 [![Build Status](https://travis-ci.org/louy/typed-sequelize.svg?branch=master)](https://travis-ci.org/louy/typed-sequelize)
 
 Typescript Typings for [Sequelize](http://sequelizejs.com).
 
-## Versions
+## Installation
 
-- [3](3/)
-- [4](4/)
+```bash
+typings install --save sequelize@4
+```
+
+## Usage
+
+See the [test folder](./test)

--- a/4/index.d.ts
+++ b/4/index.d.ts
@@ -1,0 +1,2 @@
+
+export * from './lib/sequelize';

--- a/4/lib/associations/base.d.ts
+++ b/4/lib/associations/base.d.ts
@@ -1,0 +1,104 @@
+
+import {Model} from '../model';
+import {ColumnOptions} from '../model';
+
+export abstract class Association {
+  associationType: string;
+  source: typeof Model;
+  target: typeof Model;
+  isSelfAssociation: boolean;
+  as: string;
+  isAliased: boolean;
+  foreignKey: string;
+  identifier: string;
+  toInstanceArray(objs: any): Model[];
+  inspect(): string;
+}
+
+
+/** Foreign Key Options */
+export interface ForeignKeyOptions extends ColumnOptions {
+
+  /** Attribute name for the relation */
+  name?: string;
+}
+
+
+/**
+ * Options provided when associating models
+ */
+export interface AssociationOptions {
+
+  /**
+   * Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade.
+   * For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks
+   * for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking
+   * any hooks.
+   *
+   * Defaults to false
+   */
+  hooks?: boolean;
+
+  /**
+   * The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If
+   * you create multiple associations between the same tables, you should provide an alias to be able to
+   * distinguish between them. If you provide an alias when creating the assocition, you should provide the
+   * same alias when eager loading and when getting assocated models. Defaults to the singularized name of
+   * target
+   */
+  as?: string | { singular: string, plural: string };
+
+  /**
+   * The name of the foreign key in the target table or an object representing the type definition for the
+   * foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property
+   * to set the name of the column. Defaults to the name of source + primary key of source
+   */
+  foreignKey?: string | ForeignKeyOptions;
+
+  /**
+   * What happens when delete occurs.
+   *
+   * Cascade if this is a n:m, and set null if it is a 1:m
+   *
+   * Defaults to 'SET NULL' or 'CASCADE'
+   */
+  onDelete?: string;
+
+  /**
+   * What happens when update occurs
+   *
+   * Defaults to 'CASCADE'
+   */
+  onUpdate?: string;
+
+  /**
+   * Should on update and on delete constraints be enabled on the foreign key.
+   */
+  constraints?: boolean;
+  foreignKeyConstraint?: boolean;
+
+}
+
+
+/**
+ * Options for Association Scope
+ */
+export interface AssociationScope {
+
+  /**
+   * The name of the column that will be used for the associated scope and it's value
+   */
+  [scopeName: string]: any;
+}
+
+/**
+ * Options provided for many-to-many relationships
+ */
+export interface ManyToManyOptions extends AssociationOptions {
+
+  /**
+   * A key/value set that will be used for association create and find defaults on the target.
+   * (sqlite not supported for N:M)
+   */
+  scope?: AssociationScope;
+}

--- a/4/lib/associations/belongs-to-many.d.ts
+++ b/4/lib/associations/belongs-to-many.d.ts
@@ -1,0 +1,558 @@
+
+import {Association, ManyToManyOptions, AssociationScope, ForeignKeyOptions} from './base';
+import {DataType} from '../data-types';
+import {Transaction} from '../transaction';
+import {Promise} from '../promise';
+import {
+  Model,
+  ColumnOptions,
+  WhereOptions,
+  FindOptions,
+  BulkCreateOptions,
+  InstanceUpdateOptions,
+  InstanceDestroyOptions,
+  CreateOptions
+} from '../model';
+
+/**
+ * Used for a association table in n:m associations.
+ */
+export interface ThroughOptions {
+
+  /**
+   * The model used to join both sides of the N:M association.
+   */
+  model: typeof Model;
+
+  /**
+   * A key/value set that will be used for association create and find defaults on the through model.
+   * (Remember to add the attributes to the through model)
+   */
+  scope?: AssociationScope;
+
+  /**
+   * If true a unique key will be generated from the foreign keys used (might want to turn this off and create
+   * specific unique keys when using scopes)
+   *
+   * Defaults to true
+   */
+  unique?: boolean;
+}
+
+/**
+ * Options provided when associating models with belongsToMany relationship
+ */
+export interface BelongsToManyOptions extends ManyToManyOptions {
+
+  /**
+   * The name of the table that is used to join source and target in n:m associations. Can also be a
+   * sequelize model if you want to define the junction table yourself and add extra attributes to it.
+   */
+  through: typeof Model | string | ThroughOptions;
+
+  /**
+   * The name of the foreign key in the join table (representing the target model) or an object representing
+   * the type definition for the other column (see `Sequelize.define` for syntax). When using an object, you
+   * can add a `name` property to set the name of the colum. Defaults to the name of target + primary key of
+   * target
+   */
+  otherKey?: string | ForeignKeyOptions;
+}
+
+export class BelongsToMany extends Association {
+  constructor(source: typeof Model, target: typeof Model, options: BelongsToManyOptions);
+}
+
+
+/**
+ * The options for the getAssociations mixin of the belongsToMany association.
+ * @see BelongsToManyGetAssociationsMixin
+ */
+export interface BelongsToManyGetAssociationsMixinOptions {
+
+  /**
+   * An optional where clause to limit the associated models.
+   */
+  where?: WhereOptions;
+
+  /**
+   * Apply a scope on the related model, or remove its default scope by passing false.
+   */
+  scope?: string | boolean;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The getAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    getRoles: Sequelize.BelongsToManyGetAssociationsMixin<RoleInstance>;
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyGetAssociationsMixin<TModel> {
+  /**
+   * Get everything currently associated with this, using an optional where clause.
+   * @param options The options to use when getting the associations.
+   */
+  (options?: BelongsToManyGetAssociationsMixinOptions): Promise<TModel[]>
+}
+
+/**
+ * The options for the setAssociations mixin of the belongsToMany association.
+ * @see BelongsToManySetAssociationsMixin
+ */
+export interface BelongsToManySetAssociationsMixinOptions {
+
+  /**
+   * Run validation for the join model.
+   */
+  validate?: boolean;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The setAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    setRoles: Sequelize.BelongsToManySetAssociationsMixin<RoleInstance, RoleId, UserRoleAttributes>;
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManySetAssociationsMixin<TModel, TModelPrimaryKey, TJoinTableAttributes> {
+  /**
+   * Set the associated models by passing an array of instances or their primary keys.
+   * Everything that it not in the passed array will be un-associated.
+   * @param newAssociations An array of instances or primary key of instances to associate with this. Pass null or undefined to remove all associations.
+   * @param options The options passed to `through.findAll`, `bulkCreate`, `update` and `destroy`. Can also hold additional attributes for the join table.
+   */
+  (
+    newAssociations?: Array<TModel | TModelPrimaryKey>,
+    options?: BelongsToManySetAssociationsMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | TJoinTableAttributes
+  ): Promise<void>
+}
+
+/**
+ * The options for the addAssociations mixin of the belongsToMany association.
+ * @see BelongsToManyAddAssociationsMixin
+ */
+export interface BelongsToManyAddAssociationsMixinOptions {
+
+  /**
+   * Run validation for the join model.
+   */
+  validate?: boolean;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The addAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    addRoles: Sequelize.BelongsToManyAddAssociationsMixin<RoleInstance, RoleId, UserRoleAttributes>;
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyAddAssociationsMixin<TModel, TModelPrimaryKey, TJoinTableAttributes> {
+  /**
+   * Associate several instances with this.
+   * @param newAssociations An array of instances or primary key of instances to associate with this.
+   * @param options The options passed to `through.findAll`, `bulkCreate`, `update` and `destroy`. Can also hold additional attributes for the join table.
+   */
+  (
+    newAssociations?: Array<TModel | TModelPrimaryKey>,
+    options?: BelongsToManyAddAssociationsMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | TJoinTableAttributes
+  ): Promise<void>
+}
+
+/**
+ * The options for the addAssociation mixin of the belongsToMany association.
+ * @see BelongsToManyAddAssociationMixin
+ */
+export interface BelongsToManyAddAssociationMixinOptions {
+
+  /**
+   * Run validation for the join model.
+   */
+  validate?: boolean;
+}
+
+/**
+ * The addAssociation mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    addRole: Sequelize.BelongsToManyAddAssociationMixin<RoleInstance, RoleId, UserRoleAttributes>;
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyAddAssociationMixin<TModel, TModelPrimaryKey, TJoinTableAttributes> {
+  /**
+   * Associate an instance with this.
+   * @param newAssociation An instance or the primary key of an instance to associate with this.
+   * @param options The options passed to `through.findAll`, `bulkCreate`, `update` and `destroy`. Can also hold additional attributes for the join table.
+   */
+  (
+    newAssociation?: TModel | TModelPrimaryKey,
+    options?: BelongsToManyAddAssociationMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | TJoinTableAttributes
+  ): Promise<void>
+}
+
+/**
+ * The options for the createAssociation mixin of the belongsToMany association.
+ * @see BelongsToManyCreateAssociationMixin
+ */
+export interface BelongsToManyCreateAssociationMixinOptions { }
+
+/**
+ * The createAssociation mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    createRole: Sequelize.BelongsToManyCreateAssociationMixin<RoleAttributes, UserRoleAttributes>;
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyCreateAssociationMixin<TAttributes, TModel, TJoinTableAttributes> {
+  /**
+   * Create a new instance of the associated model and associate it with this.
+   * @param values The values used to create the association.
+   * @param options Options passed to `create` and `add`. Can also hold additional attributes for the join table.
+   */
+  (
+    values?: TAttributes,
+    options?: BelongsToManyCreateAssociationMixinOptions | CreateOptions | TJoinTableAttributes
+  ): Promise<TModel>
+}
+
+/**
+ * The options for the removeAssociation mixin of the belongsToMany association.
+ * @see BelongsToManyRemoveAssociationMixin
+ */
+export interface BelongsToManyRemoveAssociationMixinOptions { }
+
+/**
+ * The removeAssociation mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    removeRole: Sequelize.BelongsToManyRemoveAssociationMixin<RoleInstance, RoleId>;
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyRemoveAssociationMixin<TModel, TModelPrimaryKey> {
+  /**
+   * Un-associate the instance.
+   * @param oldAssociated The instance or the primary key of the instance to un-associate.
+   * @param options The options passed to `through.destroy`.
+   */
+  (
+    oldAssociated?: TModel | TModelPrimaryKey,
+    options?: BelongsToManyRemoveAssociationMixinOptions | InstanceDestroyOptions
+  ): Promise<void>
+}
+
+/**
+ * The options for the removeAssociations mixin of the belongsToMany association.
+ * @see BelongsToManyRemoveAssociationsMixin
+ */
+export interface BelongsToManyRemoveAssociationsMixinOptions {
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The removeAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    removeRoles: Sequelize.BelongsToManyRemoveAssociationsMixin<RoleInstance, RoleId>;
+ *    // hasRole...
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyRemoveAssociationsMixin<TModel, TModelPrimaryKey> {
+  /**
+   * Un-associate several instances.
+   * @param oldAssociated An array of instances or primary key of instances to un-associate.
+   * @param options The options passed to `through.destroy`.
+   */
+  (
+    oldAssociateds?: Array<TModel | TModelPrimaryKey>,
+    options?: BelongsToManyRemoveAssociationsMixinOptions | InstanceDestroyOptions
+  ): Promise<void>
+}
+
+/**
+ * The options for the hasAssociation mixin of the belongsToMany association.
+ * @see BelongsToManyHasAssociationMixin
+ */
+export interface BelongsToManyHasAssociationMixinOptions { }
+
+/**
+ * The hasAssociation mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    hasRole: Sequelize.BelongsToManyHasAssociationMixin<RoleInstance, RoleId>;
+ *    // hasRoles...
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyHasAssociationMixin<TModel, TModelPrimaryKey> {
+  /**
+   * Check if an instance is associated with this.
+   * @param target The instance or the primary key of the instance to check.
+   * @param options The options passed to `getAssociations`.
+   */
+  (
+    target: TModel | TModelPrimaryKey,
+    options?: BelongsToManyHasAssociationMixinOptions | BelongsToManyGetAssociationsMixinOptions
+  ): Promise<boolean>
+}
+
+/**
+ * The options for the hasAssociations mixin of the belongsToMany association.
+ * @see BelongsToManyHasAssociationsMixin
+ */
+export interface BelongsToManyHasAssociationsMixinOptions {
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The removeAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles
+ *    // hasRole...
+ *    hasRoles: Sequelize.BelongsToManyHasAssociationsMixin<RoleInstance, RoleId>;
+ *    // countRoles...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyHasAssociationsMixin<TModel, TModelPrimaryKey> {
+  /**
+   * Check if all instances are associated with this.
+   * @param targets An array of instances or primary key of instances to check.
+   * @param options The options passed to `getAssociations`.
+   */
+  (
+    targets: Array<TModel | TModelPrimaryKey>,
+    options?: BelongsToManyHasAssociationsMixinOptions | BelongsToManyGetAssociationsMixinOptions
+  ): Promise<boolean>
+}
+
+/**
+ * The options for the countAssociations mixin of the belongsToMany association.
+ * @see BelongsToManyCountAssociationsMixin
+ */
+export interface BelongsToManyCountAssociationsMixinOptions {
+
+  /**
+   * An optional where clause to limit the associated models.
+   */
+  where?: WhereOptions;
+
+  /**
+   * Apply a scope on the related model, or remove its default scope by passing false.
+   */
+  scope?: string | boolean;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+}
+
+/**
+ * The countAssociations mixin applied to models with belongsToMany.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRoles...
+ *    // setRoles...
+ *    // addRoles...
+ *    // addRole...
+ *    // createRole...
+ *    // removeRole...
+ *    // removeRoles...
+ *    // hasRole...
+ *    // hasRoles...
+ *    countRoles: Sequelize.BelongsToManyCountAssociationsMixin;
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to-many/
+ * @see Instance
+ */
+export interface BelongsToManyCountAssociationsMixin {
+  /**
+   * Count everything currently associated with this, using an optional where clause.
+   * @param options The options to use when counting the associations.
+   */
+  (options?: BelongsToManyCountAssociationsMixinOptions): Promise<number>
+}

--- a/4/lib/associations/belongs-to.d.ts
+++ b/4/lib/associations/belongs-to.d.ts
@@ -1,0 +1,144 @@
+
+import {Association} from './base';
+import {Model, SaveOptions, CreateOptions} from '../model';
+import {DataType} from '../data-types';
+import {AssociationOptions} from './base';
+import {Promise} from '../promise';
+
+/**
+ * Options provided when associating models with belongsTo relationship
+ *
+ * @see Association class belongsTo method
+ */
+export interface BelongsToOptions extends AssociationOptions {
+
+  /**
+   * The name of the field to use as the key for the association in the target table. Defaults to the primary
+   * key of the target table
+   */
+  targetKey?: string;
+
+  /**
+   * A string or a data type to represent the identifier in the table
+   */
+  keyType?: DataType;
+
+}
+
+export class BelongsTo extends Association {
+  constructor(source: typeof Model, target: typeof Model, options: BelongsToOptions);
+}
+
+
+/**
+ * The options for the getAssociation mixin of the belongsTo association.
+ * @see BelongsToGetAssociationMixin
+ */
+export interface BelongsToGetAssociationMixinOptions {
+  /**
+   * Apply a scope on the related model, or remove its default scope by passing false.
+   */
+  scope?: string | boolean;
+}
+
+/**
+ * The getAssociation mixin applied to models with belongsTo.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsTo(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttrib>, UserAttrib {
+ *    getRole: Sequelize.BelongsToGetAssociationMixin<RoleInstance>;
+ *    // setRole...
+ *    // createRole...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to/
+ * @see Instance
+ */
+export interface BelongsToGetAssociationMixin<TModel> {
+  /**
+   * Get the associated instance.
+   * @param options The options to use when getting the association.
+   */
+  (options?: BelongsToGetAssociationMixinOptions): Promise<TModel>
+}
+
+/**
+ * The options for the setAssociation mixin of the belongsTo association.
+ * @see BelongsToSetAssociationMixin
+ */
+export interface BelongsToSetAssociationMixinOptions {
+  /**
+   * Skip saving this after setting the foreign key if false.
+   */
+  save?: boolean;
+}
+
+/**
+ * The setAssociation mixin applied to models with belongsTo.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsTo(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRole...
+ *    setRole: Sequelize.BelongsToSetAssociationMixin<RoleInstance, RoleId>;
+ *    // createRole...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to/
+ * @see Instance
+ */
+export interface BelongsToSetAssociationMixin<TModel, TPrimaryKey> {
+  /**
+   * Set the associated instance.
+   * @param newAssociation An instance or the primary key of an instance to associate with this. Pass null or undefined to remove the association.
+   * @param options the options passed to `this.save`.
+   */
+  (newAssociation?: TModel | TPrimaryKey, options?: BelongsToSetAssociationMixinOptions | SaveOptions): Promise<void>
+}
+
+/**
+ * The options for the createAssociation mixin of the belongsTo association.
+ * @see BelongsToCreateAssociationMixin
+ */
+export interface BelongsToCreateAssociationMixinOptions { }
+
+/**
+ * The createAssociation mixin applied to models with belongsTo.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsTo(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRole...
+ *    // setRole...
+ *    createRole: Sequelize.BelongsToCreateAssociationMixin<RoleAttributes>;
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/belongs-to/
+ * @see Instance
+ */
+export interface BelongsToCreateAssociationMixin<TModel> {
+  /**
+   * Create a new instance of the associated model and associate it with this.
+   * @param values The values used to create the association.
+   * @param options The options passed to `target.create` and `setAssociation`.
+   */
+  (
+    values?: Object,
+    options?: BelongsToCreateAssociationMixinOptions | CreateOptions | BelongsToSetAssociationMixinOptions
+  ): Promise<TModel>
+}
+
+export default BelongsTo;

--- a/4/lib/associations/has-many.d.ts
+++ b/4/lib/associations/has-many.d.ts
@@ -1,0 +1,516 @@
+
+import {Association, ManyToManyOptions} from './base';
+import {Model, WhereOptions, FindOptions, InstanceUpdateOptions, CreateOptions} from '../model';
+import {DataType} from '../data-types';
+import {Transaction} from '../transaction';
+import {Promise} from '../promise';
+
+/**
+ * Options provided when associating models with hasMany relationship
+ */
+export interface HasManyOptions extends ManyToManyOptions {
+
+  /**
+   * A string or a data type to represent the identifier in the table
+   */
+  keyType?: DataType;
+}
+
+export class HasMany extends Association {
+  constructor(source: typeof Model, target: typeof Model, options: HasManyOptions);
+}
+
+
+  /**
+   * The options for the getAssociations mixin of the hasMany association.
+   * @see HasManyGetAssociationsMixin
+   */
+  export interface HasManyGetAssociationsMixinOptions {
+
+    /**
+     * An optional where clause to limit the associated models.
+     */
+    where?: WhereOptions;
+
+    /**
+     * Apply a scope on the related model, or remove its default scope by passing false.
+     */
+    scope?: string | boolean;
+
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The getAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    getRoles: Sequelize.HasManyGetAssociationsMixin<RoleInstance>;
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyGetAssociationsMixin<TModel> {
+    /**
+     * Get everything currently associated with this, using an optional where clause.
+     * @param options The options to use when getting the associations.
+     */
+    (options?: HasManyGetAssociationsMixinOptions): Promise<TModel[]>
+  }
+
+  /**
+   * The options for the setAssociations mixin of the hasMany association.
+   * @see HasManySetAssociationsMixin
+   */
+  export interface HasManySetAssociationsMixinOptions {
+
+    /**
+     * Run validation for the join model.
+     */
+    validate?: boolean;
+
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The setAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    setRoles: Sequelize.HasManySetAssociationsMixin<RoleInstance, RoleId>;
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManySetAssociationsMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Set the associated models by passing an array of instances or their primary keys.
+     * Everything that it not in the passed array will be un-associated.
+     * @param newAssociations An array of instances or primary key of instances to associate with this. Pass null or undefined to remove all associations.
+     * @param options The options passed to `target.findAll` and `update`.
+     */
+    (
+      newAssociations?: Array<TModel | TModelPrimaryKey>,
+      options?: HasManySetAssociationsMixinOptions | FindOptions | InstanceUpdateOptions
+    ): Promise<void>
+  }
+
+  /**
+   * The options for the addAssociations mixin of the hasMany association.
+   * @see HasManyAddAssociationsMixin
+   */
+  export interface HasManyAddAssociationsMixinOptions {
+
+    /**
+     * Run validation for the join model.
+     */
+    validate?: boolean;
+
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The addAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    addRoles: Sequelize.HasManyAddAssociationsMixin<RoleInstance, RoleId>;
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyAddAssociationsMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Associate several instances with this.
+     * @param newAssociations An array of instances or primary key of instances to associate with this.
+     * @param options The options passed to `target.update`.
+     */
+    (
+      newAssociations?: Array<TModel | TModelPrimaryKey>,
+      options?: HasManyAddAssociationsMixinOptions | InstanceUpdateOptions
+    ): Promise<void>
+  }
+
+  /**
+   * The options for the addAssociation mixin of the hasMany association.
+   * @see HasManyAddAssociationMixin
+   */
+  export interface HasManyAddAssociationMixinOptions {
+
+    /**
+     * Run validation for the join model.
+     */
+    validate?: boolean;
+  }
+
+  /**
+   * The addAssociation mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    addRole: Sequelize.HasManyAddAssociationMixin<RoleInstance, RoleId>;
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyAddAssociationMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Associate an instance with this.
+     * @param newAssociation An instance or the primary key of an instance to associate with this.
+     * @param options The options passed to `target.update`.
+     */
+    (
+      newAssociation?: TModel | TModelPrimaryKey,
+      options?: HasManyAddAssociationMixinOptions | InstanceUpdateOptions
+    ): Promise<void>
+  }
+
+  /**
+   * The options for the createAssociation mixin of the hasMany association.
+   * @see HasManyCreateAssociationMixin
+   */
+  export interface HasManyCreateAssociationMixinOptions { }
+
+  /**
+   * The createAssociation mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    createRole: Sequelize.HasManyCreateAssociationMixin<RoleAttributes>;
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyCreateAssociationMixin<TAttributes, TModel> {
+    /**
+     * Create a new instance of the associated model and associate it with this.
+     * @param values The values used to create the association.
+     * @param options The options to use when creating the association.
+     */
+    (
+      values?: TAttributes,
+      options?: HasManyCreateAssociationMixinOptions | CreateOptions
+    ): Promise<TModel>
+  }
+
+  /**
+   * The options for the removeAssociation mixin of the hasMany association.
+   * @see HasManyRemoveAssociationMixin
+   */
+  export interface HasManyRemoveAssociationMixinOptions { }
+
+  /**
+   * The removeAssociation mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    removeRole: Sequelize.HasManyRemoveAssociationMixin<RoleInstance, RoleId>;
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyRemoveAssociationMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Un-associate the instance.
+     * @param oldAssociated The instance or the primary key of the instance to un-associate.
+     * @param options The options passed to `target.update`.
+     */
+    (
+      oldAssociated?: TModel | TModelPrimaryKey,
+      options?: HasManyRemoveAssociationMixinOptions | InstanceUpdateOptions
+    ): Promise<void>
+  }
+
+  /**
+   * The options for the removeAssociations mixin of the hasMany association.
+   * @see HasManyRemoveAssociationsMixin
+   */
+  export interface HasManyRemoveAssociationsMixinOptions {
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The removeAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    removeRoles: Sequelize.HasManyRemoveAssociationsMixin<RoleInstance, RoleId>;
+   *    // hasRole...
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyRemoveAssociationsMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Un-associate several instances.
+     * @param oldAssociated An array of instances or primary key of instances to un-associate.
+     * @param options The options passed to `target.update`.
+     */
+    (
+      oldAssociateds?: Array<TModel | TModelPrimaryKey>,
+      options?: HasManyRemoveAssociationsMixinOptions | InstanceUpdateOptions
+    ): Promise<void>
+  }
+
+  /**
+   * The options for the hasAssociation mixin of the hasMany association.
+   * @see HasManyHasAssociationMixin
+   */
+  export interface HasManyHasAssociationMixinOptions { }
+
+  /**
+   * The hasAssociation mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    hasRole: Sequelize.HasManyHasAssociationMixin<RoleInstance, RoleId>;
+   *    // hasRoles...
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyHasAssociationMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Check if an instance is associated with this.
+     * @param target The instance or the primary key of the instance to check.
+     * @param options The options passed to `getAssociations`.
+     */
+    (
+      target: TModel | TModelPrimaryKey,
+      options?: HasManyHasAssociationMixinOptions | HasManyGetAssociationsMixinOptions
+    ): Promise<boolean>
+  }
+
+  /**
+   * The options for the hasAssociations mixin of the hasMany association.
+   * @see HasManyHasAssociationsMixin
+   */
+  export interface HasManyHasAssociationsMixinOptions {
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The removeAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles
+   *    // hasRole...
+   *    hasRoles: Sequelize.HasManyHasAssociationsMixin<RoleInstance, RoleId>;
+   *    // countRoles...
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyHasAssociationsMixin<TModel, TModelPrimaryKey> {
+    /**
+     * Check if all instances are associated with this.
+     * @param targets An array of instances or primary key of instances to check.
+     * @param options The options passed to `getAssociations`.
+     */
+    (
+      targets: Array<TModel | TModelPrimaryKey>,
+      options?: HasManyHasAssociationsMixinOptions | HasManyGetAssociationsMixinOptions
+    ): Promise<boolean>
+  }
+
+  /**
+   * The options for the countAssociations mixin of the hasMany association.
+   * @see HasManyCountAssociationsMixin
+   */
+  export interface HasManyCountAssociationsMixinOptions {
+
+    /**
+     * An optional where clause to limit the associated models.
+     */
+    where?: WhereOptions;
+
+    /**
+     * Apply a scope on the related model, or remove its default scope by passing false.
+     */
+    scope?: string | boolean;
+
+    /**
+     * Transaction to run query under
+     */
+    transaction?: Transaction;
+  }
+
+  /**
+   * The countAssociations mixin applied to models with hasMany.
+   * An example of usage is as follows:
+   *
+   * ```js
+   *
+   * User.hasMany(Role);
+   *
+   * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+   *    // getRoles...
+   *    // setRoles...
+   *    // addRoles...
+   *    // addRole...
+   *    // createRole...
+   *    // removeRole...
+   *    // removeRoles...
+   *    // hasRole...
+   *    // hasRoles...
+   *    countRoles: Sequelize.HasManyCountAssociationsMixin;
+   * }
+   * ```
+   *
+   * @see http://docs.sequelizejs.com/en/latest/api/associations/has-many/
+   * @see Instance
+   */
+  export interface HasManyCountAssociationsMixin {
+    /**
+     * Count everything currently associated with this, using an optional where clause.
+     * @param options The options to use when counting the associations.
+     */
+    (options?: HasManyCountAssociationsMixinOptions): Promise<number>
+  }
+

--- a/4/lib/associations/has-one.d.ts
+++ b/4/lib/associations/has-one.d.ts
@@ -1,0 +1,136 @@
+
+import {Association, AssociationOptions} from './base';
+import {Model, SaveOptions, CreateOptions} from '../model';
+import {DataType} from '../data-types';
+import {Promise} from '../promise';
+
+/**
+ * Options provided when associating models with hasOne relationship
+ */
+export interface HasOneOptions extends AssociationOptions {
+
+  /**
+   * A string or a data type to represent the identifier in the table
+   */
+  keyType?: DataType;
+}
+
+export class HasOne extends Association {
+  constructor(source: typeof Model, target: typeof Model, options: HasOneOptions);
+}
+
+
+/**
+ * The options for the getAssociation mixin of the hasOne association.
+ * @see HasOneGetAssociationMixin
+ */
+export interface HasOneGetAssociationMixinOptions {
+  /**
+   * Apply a scope on the related model, or remove its default scope by passing false.
+   */
+  scope?: string | boolean;
+}
+
+/**
+ * The getAssociation mixin applied to models with hasOne.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.hasOne(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttrib>, UserAttrib {
+ *    getRole: Sequelize.HasOneGetAssociationMixin<RoleInstance>;
+ *    // setRole...
+ *    // createRole...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/has-one/
+ * @see Instance
+ */
+export interface HasOneGetAssociationMixin<TModel> {
+  /**
+   * Get the associated instance.
+   * @param options The options to use when getting the association.
+   */
+  (options?: HasOneGetAssociationMixinOptions): Promise<TModel>
+}
+
+/**
+ * The options for the setAssociation mixin of the hasOne association.
+ * @see HasOneSetAssociationMixin
+ */
+export interface HasOneSetAssociationMixinOptions {
+  /**
+   * Skip saving this after setting the foreign key if false.
+   */
+  save?: boolean;
+}
+
+/**
+ * The setAssociation mixin applied to models with hasOne.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.hasOne(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRole...
+ *    setRole: Sequelize.HasOneSetAssociationMixin<RoleInstance, RoleId>;
+ *    // createRole...
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/has-one/
+ * @see Instance
+ */
+export interface HasOneSetAssociationMixin<TModel, TModelPrimaryKey> {
+  /**
+   * Set the associated instance.
+   * @param newAssociation An instance or the primary key of an instance to associate with this. Pass null or undefined to remove the association.
+   * @param options The options passed to `getAssocation` and `target.save`.
+   */
+  (
+    newAssociation?: TModel | TModelPrimaryKey,
+    options?: HasOneSetAssociationMixinOptions | HasOneGetAssociationMixinOptions | SaveOptions
+  ): Promise<void>
+}
+
+/**
+ * The options for the createAssociation mixin of the hasOne association.
+ * @see HasOneCreateAssociationMixin
+ */
+export interface HasOneCreateAssociationMixinOptions { }
+
+
+/**
+ * The createAssociation mixin applied to models with hasOne.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.hasOne(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttributes>, UserAttributes {
+ *    // getRole...
+ *    // setRole...
+ *    createRole: Sequelize.HasOneCreateAssociationMixin<RoleAttributes>;
+ * }
+ * ```
+ *
+ * @see http://docs.sequelizejs.com/en/latest/api/associations/has-one/
+ * @see Instance
+ */
+export interface HasOneCreateAssociationMixin<TAttributes, TModel> {
+  /**
+   * Create a new instance of the associated model and associate it with this.
+   * @param values The values used to create the association.
+   * @param options The options passed to `target.create` and `setAssociation`.
+   */
+  (
+    values?: TAttributes,
+    options?: HasOneCreateAssociationMixinOptions | HasOneSetAssociationMixinOptions | CreateOptions
+  ): Promise<TModel>
+}

--- a/4/lib/associations/index.d.ts
+++ b/4/lib/associations/index.d.ts
@@ -1,0 +1,6 @@
+
+export * from './base';
+export * from './belongs-to';
+export * from './has-one';
+export * from './has-many';
+export * from './belongs-to-many';

--- a/4/lib/data-types.d.ts
+++ b/4/lib/data-types.d.ts
@@ -1,0 +1,636 @@
+/**
+ * The datatypes are used when defining a new model using `Sequelize.define`, like this:
+ * ```js
+ * sequelize.define('model', {
+ *   column: DataTypes.INTEGER
+ * })
+ * ```
+ * When defining a model you can just as easily pass a string as type, but often using the types defined here is beneficial. For example, using `DataTypes.BLOB`, mean
+ * that that column will be returned as an instance of `Buffer` when being fetched by sequelize.
+ *
+ * Some data types have special properties that can be accessed in order to change the data type.
+ * For example, to get an unsigned integer with zerofill you can do `DataTypes.INTEGER.UNSIGNED.ZEROFILL`.
+ * The order you access the properties in do not matter, so `DataTypes.INTEGER.ZEROFILL.UNSIGNED` is fine as well. The available properties are listed under each data type.
+ *
+ * To provide a length for the data type, you can invoke it like a function: `INTEGER(2)`
+ *
+ * Three of the values provided here (`NOW`, `UUIDV1` and `UUIDV4`) are special default values, that should not be used to define types. Instead they are used as shorthands for
+ * defining default values. For example, to get a uuid field with a default value generated following v1 of the UUID standard:
+ * ```js
+ * sequelize.define('model', {
+ *   uuid: {
+ *     type: DataTypes.UUID,
+ *     defaultValue: DataTypes.UUIDV1,
+ *     primaryKey: true
+ *   }
+ * })
+ * ```
+ * There may be times when you want to generate your own UUID conforming to some other algorithm. This is accomplised
+ * using the defaultValue property as well, but instead of specifying one of the supplied UUID types, you return a value
+ * from a function.
+ * ```js
+ * sequelize.define('model', {
+ *   uuid: {
+ *     type: DataTypes.UUID,
+ *     defaultValue: function() {
+ *       return generateMyId()
+ *     },
+ *     primaryKey: true
+ *   }
+ * })
+ * ```
+ */
+
+export type DataType = string | AbstractDataTypeStatic | AbstractDataType;
+
+export const ABSTRACT: AbstractDataTypeStatic;
+
+export interface AbstractDataTypeStatic {
+  new (options: Object): AbstractDataType;
+  (options: Object): AbstractDataType;
+  key: string;
+  warn(link: string, text: string): void;
+}
+
+export interface AbstractDataType {
+  key: string;
+  dialectTypes: string;
+  toSql(): string;
+  stringify(value: any, options?: Object): string;
+  toString(options: Object): string;
+}
+
+/**
+ * A variable length string. Default length 255
+ *
+ * Available properties: `BINARY`
+ *
+ * @property STRING
+ */
+export const STRING: StringDataTypeStatic;
+
+export interface StringDataTypeStatic extends AbstractDataTypeStatic {
+  new (length?: number, binary?: boolean): StringDataType;
+  new (options?: StringDataTypeOptions): StringDataType;
+  (length?: number, binary?: boolean): StringDataType;
+  (options?: StringDataTypeOptions): StringDataType;
+}
+
+export interface StringDataType extends AbstractDataType {
+  options: StringDataTypeOptions;
+  BINARY: this;
+  validate(value: any): boolean;
+}
+
+export interface StringDataTypeOptions {
+  length?: number;
+  binary?: boolean;
+}
+
+/**
+ * A fixed length string. Default length 255
+ *
+ * Available properties: `BINARY`
+ *
+ * @property CHAR
+ */
+export const CHAR: CharDataTypeStatic;
+
+export interface CharDataTypeStatic extends StringDataTypeStatic {
+  new (length?: number, binary?: boolean): CharDataType;
+  new (options?: CharDataTypeOptions): CharDataType;
+  (length?: number, binary?: boolean): CharDataType;
+  (options?: CharDataTypeOptions): CharDataType;
+}
+
+export interface CharDataType extends StringDataType {
+  options: CharDataTypeOptions;
+}
+
+export interface CharDataTypeOptions extends StringDataTypeOptions {}
+
+/**
+ * An (un)limited length text column. Available lengths: `tiny`, `medium`, `long`
+ * @property TEXT
+ */
+export const TEXT: TextDataTypeStatic;
+
+export interface TextDataTypeStatic extends AbstractDataTypeStatic {
+  new (length?: number): TextDataType;
+  (options?: TextDataTypeOptions): TextDataType;
+}
+
+export interface TextDataType extends AbstractDataType {
+  options: TextDataTypeOptions;
+  validate(value: any): boolean;
+}
+
+export interface TextDataTypeOptions {
+ length?: number;
+}
+
+export const NUMBER: NumberDataTypeStatic;
+
+export interface NumberDataTypeStatic extends AbstractDataTypeStatic {
+  new (options?: NumberDataTypeOptions): NumberDataType;
+  (options?: NumberDataTypeOptions): NumberDataType;
+  options: NumberDataTypeOptions;
+  validate(value: any): boolean;
+  UNSIGNED: this;
+  ZEROFILL: this;
+}
+
+export interface NumberDataType extends AbstractDataType {
+  options: NumberDataTypeOptions;
+  validate(value: any): boolean;
+  UNSIGNED: this;
+  ZEROFILL: this;
+}
+
+export interface NumberDataTypeOptions {
+  length?: number;
+  zerofill?: boolean;
+  decimals?: number;
+  precision?: number;
+  scale?: number;
+  unsigned?: boolean;
+}
+
+/**
+ * A 32 bit integer.
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property INTEGER
+ */
+export const INTEGER: IntegerDataTypeStatic;
+
+export interface IntegerDataTypeStatic extends NumberDataTypeStatic {
+  new (options?: NumberDataTypeOptions): IntegerDataType;
+  (options?: NumberDataTypeOptions): IntegerDataType;
+}
+
+export interface IntegerDataType extends NumberDataType {
+  options: NumberDataTypeOptions;
+}
+
+export interface IntegerDataTypeOptions {
+  length?: number;
+}
+
+/**
+ * A 64 bit integer.
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property BIGINT
+ */
+export const BIGINT: BigIntDataTypeStatic;
+
+export interface BigIntDataTypeStatic extends NumberDataTypeStatic {
+  new (options?: BigIntDataTypeOptions): BigIntDataType;
+  (options?: BigIntDataTypeOptions): BigIntDataType;
+}
+
+export interface BigIntDataType extends NumberDataType {
+  options: BigIntDataTypeOptions;
+}
+
+export interface BigIntDataTypeOptions {
+  length?: number;
+}
+
+/**
+ * Floating point number (4-byte precision). Accepts one or two arguments for precision
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property FLOAT
+ */
+ export const FLOAT: FloatDataTypeStatic;
+
+ export interface FloatDataTypeStatic extends NumberDataTypeStatic {
+   new (length?: number, decimals?: number): FloatDataType;
+   new (options?: FloatDataTypeOptions): FloatDataType;
+   (length?: number, decimals?: number): FloatDataType;
+   (options?: FloatDataTypeOptions): FloatDataType;
+ }
+
+ export interface FloatDataType extends NumberDataType {
+   options: FloatDataTypeOptions;
+ }
+
+ export interface FloatDataTypeOptions {
+   length?: number;
+   decimals?: number;
+ }
+
+
+ /**
+  * Floating point number (4-byte precision). Accepts one or two arguments for precision
+  *
+  * Available properties: `UNSIGNED`, `ZEROFILL`
+  *
+  * @property REAL
+  */
+export const REAL: RealDataTypeStatic;
+
+export interface RealDataTypeStatic extends NumberDataTypeStatic {
+  new (length?: number, decimals?: number): RealDataType;
+  new (options?: RealDataTypeOptions): RealDataType;
+  (length?: number, decimals?: number): RealDataType;
+  (options?: RealDataTypeOptions): RealDataType;
+}
+
+export interface RealDataType extends NumberDataType {
+  options: RealDataTypeOptions;
+}
+
+export interface RealDataTypeOptions {
+  length?: number;
+  decimals?: number;
+}
+
+
+/**
+ * Floating point number (8-byte precision). Accepts one or two arguments for precision
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property DOUBLE
+ */
+export const DOUBLE: DoubleDataTypeStatic;
+
+export interface DoubleDataTypeStatic extends NumberDataTypeStatic {
+  new (length?: number, decimals?: number): DoubleDataType;
+  new (options?: DoubleDataTypeOptions): DoubleDataType;
+  (length?: number, decimals?: number): DoubleDataType;
+  (options?: DoubleDataTypeOptions): DoubleDataType;
+}
+
+export interface DoubleDataType extends NumberDataType {
+  options: DoubleDataTypeOptions;
+}
+
+export interface DoubleDataTypeOptions {
+  length?: number;
+  decimals?: number;
+}
+
+/**
+ * Decimal number. Accepts one or two arguments for precision
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property DECIMAL
+ */
+export const DECIMAL: DecimalDataTypeStatic;
+
+export interface DecimalDataTypeStatic extends NumberDataTypeStatic {
+  new (precision?: number, scale?: number): DecimalDataType;
+  new (options?: DecimalDataTypeOptions): DecimalDataType;
+  (precision?: number, scale?: number): DecimalDataType;
+  (options?: DecimalDataTypeOptions): DecimalDataType;
+  PRECISION: this;
+  SCALE: this;
+}
+
+export interface DecimalDataType extends NumberDataType {
+  options: DecimalDataTypeOptions;
+}
+
+export interface DecimalDataTypeOptions {
+  precision?: number;
+  scale?: number;
+}
+
+/**
+ * A boolean / tinyint column, depending on dialect
+ * @property BOOLEAN
+ */
+export const BOOLEAN: AbstractDataTypeStatic;
+
+/**
+ * A time column
+ * @property TIME
+ */
+export const TIME: AbstractDataTypeStatic;
+
+/**
+ * A datetime column
+ * @property DATE
+ */
+export const DATE: DateDataTypeStatic;
+
+export interface DateDataTypeStatic extends AbstractDataTypeStatic {
+  new (length?: any): DateDataType;
+  new (options?: DateDataTypeOptions): DateDataType;
+  (length?: any): DateDataType;
+  (options?: DateDataTypeOptions): DateDataType;
+}
+
+export interface DateDataType extends AbstractDataTypeStatic {
+  options: DateDataTypeOptions;
+}
+
+export interface DateDataTypeOptions {
+  length?: any;
+}
+
+/**
+ * A date only column
+ * @property DATEONLY
+ */
+export const DATEONLY: DateOnlyDataTypeStatic;
+
+export interface DateOnlyDataTypeStatic extends AbstractDataTypeStatic {
+  new (length: any): DateOnlyDataType;
+  new (options: DateOnlyDataTypeOptions): DateOnlyDataType;
+  (length: any): DateOnlyDataType;
+  (options: DateOnlyDataTypeOptions): DateOnlyDataType;
+}
+
+export interface DateOnlyDataType extends AbstractDataType {
+  options: DateOnlyDataTypeOptions;
+}
+
+export interface DateOnlyDataTypeOptions {
+  length?: any;
+}
+
+/**
+ * A key / value column. Only available in postgres.
+ * @property HSTORE
+ */
+export const HSTORE: AbstractDataTypeStatic;
+
+/**
+ * A JSON string column. Only available in postgres.
+ * @property JSON
+ */
+export const JSON: AbstractDataTypeStatic;
+
+/**
+ * A pre-processed JSON data column. Only available in postgres.
+ * @property JSONB
+ */
+export const JSONB: AbstractDataTypeStatic;
+
+/**
+ * A default value of the current timestamp
+ * @property NOW
+ */
+export const NOW: AbstractDataTypeStatic;
+
+/**
+ * Binary storage. Available lengths: `tiny`, `medium`, `long`
+ *
+ * @property BLOB
+ */
+export const BLOB: BlobDataTypeStatic;
+
+export interface BlobDataTypeStatic extends AbstractDataTypeStatic {
+  new (length?: number): BlobDataType;
+  new (options?: BlobDataTypeOptions): BlobDataType;
+  (length?: number): BlobDataType;
+  (options?: BlobDataTypeOptions): BlobDataType;
+}
+
+export interface BlobDataType extends AbstractDataType {
+  options: BlobDataTypeOptions;
+  escape: boolean;
+}
+
+export interface BlobDataTypeOptions {
+  length?: number;
+  escape?: boolean;
+}
+
+/**
+ * Range types are data types representing a range of values of some element type (called the range's subtype).
+ * Only available in postgres.
+ * See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
+ * @property RANGE
+ */
+export const RANGE: RangeDataTypeStatic;
+
+export type RangeableDataType = IntegerDataTypeStatic | IntegerDataType | BigIntDataTypeStatic | BigIntDataType
+  | DecimalDataTypeStatic | DecimalDataType | DateOnlyDataTypeStatic | DateOnlyDataType | DateDataTypeStatic | DateDataType;
+
+export interface RangeDataTypeStatic extends AbstractDataTypeStatic {
+  new <T extends RangeableDataType>(subtype?: T): RangeDataType<T>;
+  new <T extends RangeableDataType>(options: RangeDataTypeOptions<T>): RangeDataType<T>;
+  <T extends RangeableDataType>(subtype?: T): RangeDataType<T>;
+  <T extends RangeableDataType>(options: RangeDataTypeOptions<T>): RangeDataType<T>;
+}
+
+export interface RangeDataType<T extends RangeableDataType> extends AbstractDataType {
+  options: RangeDataTypeOptions<T>;
+}
+
+export interface RangeDataTypeOptions<T extends RangeableDataType> {
+  subtype?: T;
+}
+
+/**
+ * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
+ * @property UUID
+ */
+export const UUID: AbstractDataTypeStatic;
+
+/**
+ * A default unique universal identifier generated following the UUID v1 standard
+ * @property UUIDV1
+ */
+export const UUIDV1: AbstractDataTypeStatic;
+
+/**
+ * A default unique universal identifier generated following the UUID v4 standard
+ * @property UUIDV4
+ */
+export const UUIDV4: AbstractDataTypeStatic;
+
+/**
+ * A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model that is returned to the user but not stored in the DB.
+ *
+ * You could also use it to validate a value before permuting and storing it. Checking password length before hashing it for example:
+ * ```js
+ * sequelize.define('user', {
+ *   password_hash: DataTypes.STRING,
+ *   password: {
+ *     type: DataTypes.VIRTUAL,
+ *     set: function (val) {
+ *       this.setDataValue('password', val); // Remember to set the data value, otherwise it won't be validated
+ *       this.setDataValue('password_hash', this.salt + val);
+ *     },
+ *     validate: {
+ *       isLongEnough: function (val) {
+ *         if (val.length < 7) {
+ *           throw new Error("Please choose a longer password")
+ *         }
+ *       }
+ *     }
+ *   }
+ * })
+ * ```
+ *
+ * VIRTUAL also takes a return type and dependency fields as arguments
+ * If a virtual attribute is present in `attributes` it will automatically pull in the extra fields as well.
+ * Return type is mostly useful for setups that rely on types like GraphQL.
+ * ```js
+ * {
+ *   active: {
+ *     type: new DataTypes.VIRTUAL(DataTypes.BOOLEAN, ['createdAt']),
+ *     get: function() {
+ *       return this.get('createdAt') > Date.now() - (7 * 24 * 60 * 60 * 1000)
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * In the above code the password is stored plainly in the password field so it can be validated, but is never stored in the DB.
+ * @property VIRTUAL
+ * @alias NONE
+ */
+export const VIRTUAL: VirtualDataTypeStatic;
+
+export interface VirtualDataTypeStatic extends AbstractDataTypeStatic {
+  new <T extends AbstractDataTypeStatic|AbstractDataType>(ReturnType: T, fields?: string[]): VirtualDataType<T>;
+  <T extends AbstractDataTypeStatic|AbstractDataType>(ReturnType: T, fields?: string[]): VirtualDataType<T>;
+}
+
+export interface VirtualDataType<T extends AbstractDataTypeStatic|AbstractDataType> extends AbstractDataType {
+  returnType: T;
+  fields: string[];
+}
+
+/**
+ * An enumeration. `DataTypes.ENUM('value', 'another value')`.
+ *
+ * @property ENUM
+ */
+export const ENUM: EnumDataTypeStatic;
+
+export interface EnumDataTypeStatic extends AbstractDataTypeStatic {
+  new <T extends string>(...values: T[]): EnumDataType<T>;
+  new <T extends string>(options: EnumDataTypeOptions<T>): EnumDataType<T>;
+  <T extends string>(...values: T[]): EnumDataType<T>;
+  <T extends string>(options: EnumDataTypeOptions<T>): EnumDataType<T>;
+}
+
+export interface EnumDataType<T extends string> extends AbstractDataType {
+  values: T[];
+  options: EnumDataTypeOptions<T>;
+}
+
+export interface EnumDataTypeOptions<T extends string> {
+  values: T[];
+}
+
+/**
+ * An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
+ * @property ARRAY
+ */
+export const ARRAY: ArrayDataTypeStatic;
+
+export interface ArrayDataTypeStatic extends AbstractDataTypeStatic {
+  new <T extends AbstractDataTypeStatic|AbstractDataType>(type: T): ArrayDataType<T>;
+  new <T extends AbstractDataTypeStatic|AbstractDataType>(options: ArrayDataTypeOptions<T>): ArrayDataType<T>;
+  <T extends AbstractDataTypeStatic|AbstractDataType>(type: T): ArrayDataType<T>;
+  <T extends AbstractDataTypeStatic|AbstractDataType>(options: ArrayDataTypeOptions<T>): ArrayDataType<T>;
+  is<T extends AbstractDataTypeStatic|AbstractDataType>(obj: any, type: T): obj is ArrayDataType<T>;
+}
+
+export interface ArrayDataType<T extends AbstractDataTypeStatic|AbstractDataType> extends AbstractDataType {
+  options: ArrayDataTypeOptions<T>;
+}
+
+export interface ArrayDataTypeOptions<T extends AbstractDataTypeStatic|AbstractDataType> {
+  type: T;
+}
+
+/**
+ * A geometry datatype represents two dimensional spacial objects.
+ * @property GEOMETRY
+ */
+export const GEOMETRY: GeometryDataTypeStatic;
+
+export interface GeometryDataTypeStatic extends AbstractDataTypeStatic {
+  new (type: string, srid?: number): GeometryDataType;
+  new (options: GeometryDataTypeOptions): GeometryDataType;
+  (type: string, srid?: number): GeometryDataType;
+  (options: GeometryDataTypeOptions): GeometryDataType;
+}
+
+export interface GeometryDataType extends AbstractDataType {
+  options: GeometryDataTypeOptions;
+  type: string;
+  srid?: number;
+  escape: boolean;
+}
+
+export interface GeometryDataTypeOptions {
+  type: string;
+  srid?: number;
+}
+
+/**
+ * A geography datatype represents two dimensional spacial objects in an elliptic coord system.
+ */
+export const GEOGRAPHY: GeographyDataTypeStatic;
+
+export interface GeographyDataTypeStatic extends AbstractDataTypeStatic {
+  new (type: string, srid?: number): GeographyDataType;
+  new (options: GeographyDataTypeOptions): GeographyDataType;
+  (type: string, srid?: number): GeographyDataType;
+  (options: GeographyDataTypeOptions): GeographyDataType;
+}
+
+export interface GeographyDataType extends AbstractDataType {
+  options: GeographyDataTypeOptions;
+  type: string;
+  srid?: number;
+  escape: boolean;
+}
+
+export interface GeographyDataTypeOptions {
+  type: string;
+  srid?: number;
+}
+
+export const NONE: typeof VIRTUAL;
+// export ['DOUBLE PRECISION']: typeof DOUBLE;
+
+export interface DataTypes {
+  ABSTRACT: typeof ABSTRACT;
+  STRING: typeof STRING;
+  CHAR: typeof CHAR;
+  TEXT: typeof TEXT;
+  NUMBER: typeof NUMBER;
+  INTEGER: typeof INTEGER;
+  BIGINT: typeof BIGINT;
+  FLOAT: typeof FLOAT;
+  REAL: typeof REAL;
+  DOUBLE: typeof DOUBLE;
+  DECIMAL: typeof DECIMAL;
+  BOOLEAN: typeof BOOLEAN;
+  TIME: typeof TIME;
+  DATE: typeof DATE;
+  DATEONLY: typeof DATEONLY;
+  HSTORE: typeof HSTORE;
+  JSON: typeof JSON;
+  JSONB: typeof JSONB;
+  NOW: typeof NOW;
+  BLOB: typeof BLOB;
+  RANGE: typeof RANGE;
+  UUID: typeof UUID;
+  UUIDV1: typeof UUIDV1;
+  UUIDV4: typeof UUIDV4;
+  VIRTUAL: typeof VIRTUAL;
+  ENUM: typeof ENUM;
+  ARRAY: typeof ARRAY;
+  GEOMETRY: typeof GEOMETRY;
+  GEOGRAPHY: typeof GEOGRAPHY;
+  'DOUBLE PRECISION': typeof DOUBLE;
+}
+export const DataTypes: DataTypes;

--- a/4/lib/deferrable.d.ts
+++ b/4/lib/deferrable.d.ts
@@ -1,0 +1,102 @@
+
+export interface AbstractDeferrableStatic {
+  new (): AbstractDeferrable;
+  (): AbstractDeferrable;
+}
+export interface AbstractDeferrable {
+  toString(): string;
+  toSql(): string;
+}
+
+export interface InitiallyDeferredDeferrableStatic extends AbstractDeferrableStatic {
+  new (): InitiallyDeferredDeferrable;
+  (): InitiallyDeferredDeferrable;
+}
+export interface InitiallyDeferredDeferrable extends AbstractDeferrable {}
+export const INITIALLY_DEFERRED: InitiallyDeferredDeferrableStatic;
+
+export interface InitiallyImmediateDeferrableStatic extends AbstractDeferrableStatic {
+  new (): InitiallyImmediateDeferrable;
+  (): InitiallyImmediateDeferrable;
+}
+export interface InitiallyImmediateDeferrable extends AbstractDeferrable {}
+export const INITIALLY_IMMEDIATE: InitiallyImmediateDeferrableStatic;
+
+
+/**
+ * Will set the constraints to not deferred. This is the default in PostgreSQL and it make
+ * it impossible to dynamically defer the constraints within a transaction.
+ */
+export interface NotDeferrableStatic extends AbstractDeferrableStatic {
+  new (): NotDeferrable;
+  (): NotDeferrable;
+}
+export interface NotDeferrable {}
+export const NOT: NotDeferrableStatic;
+
+
+/**
+ * Will trigger an additional query at the beginning of a
+ * transaction which sets the constraints to deferred.
+ *
+ * @param constraints An array of constraint names. Will defer all constraints by default.
+ */
+export interface SetDeferredDeferrableStatic extends AbstractDeferrableStatic {
+  new (constraints: string[]): SetDeferredDeferrable;
+  (constraints: string[]): SetDeferredDeferrable;
+}
+export interface SetDeferredDeferrable {}
+export const SET_DEFERRED: SetDeferredDeferrableStatic;
+
+
+/**
+ * Will trigger an additional query at the beginning of a
+ * transaction which sets the constraints to immediately.
+ *
+ * @param constraints An array of constraint names. Will defer all constraints by default.
+ */
+export interface SetImmediateDeferrableStatic extends AbstractDeferrableStatic {
+  new (constraints: string[]): SetImmediateDeferrable;
+  (constraints: string[]): SetImmediateDeferrable;
+}
+export interface SetImmediateDeferrable {}
+export const SET_IMMEDIATE: SetImmediateDeferrableStatic;
+
+/**
+ * A collection of properties related to deferrable constraints. It can be used to
+ * make foreign key constraints deferrable and to set the constaints within a
+ * transaction. This is only supported in PostgreSQL.
+ *
+ * The foreign keys can be configured like this. It will create a foreign key
+ * that will check the constraints immediately when the data was inserted.
+ *
+ * ```js
+ * sequelize.define('Model', {
+ *   foreign_id: {
+ *     type: Sequelize.INTEGER,
+ *     references: {
+ *       model: OtherModel,
+ *       key: 'id',
+ *       deferrable: Sequelize.Deferrable.INITIALLY_IMMEDIATE
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * The constraints can be configured in a transaction like this. It will
+ * trigger a query once the transaction has been started and set the constraints
+ * to be checked at the very end of the transaction.
+ *
+ * ```js
+ * sequelize.transaction({
+ *   deferrable: Sequelize.Deferrable.SET_DEFERRED
+ * });
+ * ```
+ */
+export const Deferrable: {
+  INITIALLY_DEFERRED: InitiallyDeferredDeferrableStatic;
+  INITIALLY_IMMEDIATE: InitiallyImmediateDeferrableStatic;
+  NOT: NotDeferrableStatic;
+  SET_DEFERRED: SetDeferredDeferrableStatic;
+  SET_IMMEDIATE: SetImmediateDeferrableStatic;
+}

--- a/4/lib/errors.d.ts
+++ b/4/lib/errors.d.ts
@@ -1,0 +1,153 @@
+
+/**
+ * The Base Error all Sequelize Errors inherit from.
+ */
+export class BaseError extends Error {
+  name: string;
+}
+
+/**
+ * Scope Error. Thrown when the sequelize cannot query the specified scope.
+ */
+export class SequelizeScopeError extends BaseError { }
+
+export class ValidationError extends BaseError {
+
+  /** Array of ValidationErrorItem objects describing the validation errors */
+  errors: ValidationErrorItem[];
+
+  /**
+   * Validation Error. Thrown when the sequelize validation has failed. The error contains an `errors`
+   * property, which is an array with 1 or more ValidationErrorItems, one for each validation that failed.
+   *
+   * @param message Error message
+   * @param errors  Array of ValidationErrorItem objects describing the validation errors
+   */
+  constructor(message: string, errors?: ValidationErrorItem[]);
+
+  /**
+   * Gets all validation error items for the path / field specified.
+   *
+   * @param path The path to be checked for error items
+   */
+  get(path: string): ValidationErrorItem[];
+
+}
+
+export class ValidationErrorItem {
+
+  /** An error message */
+  message: string;
+
+  /** The type of the validation error */
+  type: string;
+
+  /** The field that triggered the validation error */
+  path: string;
+
+  /** The value that generated the error */
+  value: string;
+
+  /**
+   * Validation Error Item
+   * Instances of this class are included in the `ValidationError.errors` property.
+   *
+   * @param message An error message
+   * @param type The type of the validation error
+   * @param path The field that triggered the validation error
+   * @param value The value that generated the error
+   */
+  constructor(message?: string, type?: string, path?: string, value?: string);
+
+}
+
+export class DatabaseError extends BaseError {
+
+  /** The database specific error which triggered this one */
+  parent: Error;
+
+  /** The database specific error which triggered this one */
+  original: Error;
+
+  /** The SQL that triggered the error */
+  sql: string;
+
+  /**
+   * A base class for all database related errors.
+   * @param parent The database specific error which triggered this one
+   */
+  constructor(parent: Error);
+}
+
+/** Thrown when a database query times out because of a deadlock */
+export class TimeoutError extends DatabaseError { }
+
+/**
+ * Thrown when a unique constraint is violated in the database
+ */
+export class UniqueConstraintError extends DatabaseError {
+  errors: ValidationErrorItem[];
+  fields: { [field: string]: string };
+  constructor(options?: { parent?: Error, message?: string, errors?: ValidationErrorItem[] });
+}
+
+/**
+ * Thrown when a foreign key constraint is violated in the database
+ */
+export class ForeignKeyConstraintError extends DatabaseError {
+  table: string;
+  fields: { [field: string]: string };
+  value: any;
+  index: string;
+  constructor(options: { parent?: Error, message?: string, index?: string, fields?: string[], table?: string });
+}
+
+/**
+ * Thrown when an exclusion constraint is violated in the database
+ */
+export class ExclusionConstraintError extends DatabaseError {
+  constraint: string;
+  fields: { [field: string]: string };
+  table: string;
+  constructor(options: { parent?: Error, message?: string, constraint?: string, fields?: string[], table?: string });
+}
+
+/**
+ * A base class for all connection related errors.
+ */
+export class ConnectionError extends BaseError {
+  parent: Error;
+  original: Error;
+  constructor(parent: Error);
+}
+
+/**
+ * Thrown when a connection to a database is refused
+ */
+export class ConnectionRefusedError extends ConnectionError { }
+
+/**
+ * Thrown when a connection to a database is refused due to insufficient privileges
+ */
+export class AccessDeniedError extends ConnectionError { }
+
+/**
+ * Thrown when a connection to a database has a hostname that was not found
+ */
+export class HostNotFoundError extends ConnectionError { }
+
+/**
+ * Thrown when a connection to a database has a hostname that was not reachable
+ */
+export class HostNotReachableError extends ConnectionError { }
+
+
+/**
+ * Thrown when a connection to a database has invalid values for any of the connection parameters
+ */
+export class InvalidConnectionError extends ConnectionError { }
+
+/**
+ * Thrown when a connection to a database times out
+ */
+export interface ConnectionTimedOutError extends ConnectionError { }

--- a/4/lib/model-manager.d.ts
+++ b/4/lib/model-manager.d.ts
@@ -1,0 +1,23 @@
+
+import {Model} from './model';
+import {Sequelize} from './sequelize';
+
+export class ModelManager {
+  sequelize: Sequelize;
+  models: Array<typeof Model>;
+  all: Array<typeof Model>;
+  
+  constructor(sequelize: Sequelize);
+  addModel<T extends typeof Model>(model: T): T;
+  removeModel(model: typeof Model): void;
+  getModel(against: any, options?: {attribute?: string}): typeof Model;
+
+  /**
+   * Iterate over Models in an order suitable for e.g. creating tables. Will
+   * take foreign key constraints into account so that dependencies are visited
+   * before dependents.
+   */
+  forEachModel(iterator: (model: typeof Model, name: string) => any, options?: {reverse?: boolean}): void;
+}
+
+export default ModelManager;

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1,0 +1,2424 @@
+
+import {Promise} from './promise';
+import {Col, Fn, Literal, Where, And, Or} from './utils';
+import {SyncOptions} from './sequelize';
+import {QueryOptions} from './query-interface';
+import {Transaction} from './transaction';
+import {DataType} from './data-types';
+import {Sequelize} from './sequelize';
+import {AbstractDeferrable} from './deferrable';
+import {ModelManager} from './model-manager';
+import {
+  Association,
+  BelongsTo,
+  BelongsToOptions,
+  HasOne,
+  HasOneOptions,
+  HasMany,
+  HasManyOptions,
+  BelongsToMany,
+  BelongsToManyOptions
+} from './associations/index';
+
+export type GroupOption = string | Fn | Col | (string | Fn | Col)[];
+
+/**
+ * Options to pass to Model on drop
+ */
+export interface DropOptions {
+
+  /**
+   * Also drop all objects depending on this table, such as views. Only works in postgres
+   */
+  cascade?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+}
+
+/**
+ * Schema Options provided for applying a schema to a model
+ */
+export interface SchemaOptions {
+
+  /**
+   * The character(s) that separates the schema name from the table name
+   */
+  schemaDelimeter?: string,
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: Function | boolean
+
+}
+
+/**
+ * Scope Options for Model.scope
+ */
+export interface ScopeOptions {
+
+  /**
+   * The scope(s) to apply. Scopes can either be passed as consecutive arguments, or as an array of arguments.
+   * To apply simple scopes and scope functions with no arguments, pass them as strings. For scope function,
+   * pass an object, with a `method` property. The value can either be a string, if the method does not take
+   * any arguments, or an array, where the first element is the name of the method, and consecutive elements
+   * are arguments to that method. Pass null to remove all scopes, including the default.
+   */
+  method: string | Array<any>;
+
+}
+
+/**
+ * Where Complex nested query
+ */
+export interface WhereNested {
+  $and: Array<WhereAttributeHash | WhereLogic>;
+  $or: Array<WhereAttributeHash | WhereLogic>;
+}
+
+/**
+ * Nested where Postgre Statement
+ */
+export interface WherePGStatement {
+  $any: Array<string | number>;
+  $all: Array<string | number>;
+}
+
+/**
+ * Where Geometry Options
+ */
+export interface WhereGeometryOptions {
+  type: string;
+  coordinates: Array<Array<number> | number>;
+}
+
+/**
+ * Logic of where statement
+ */
+export interface WhereLogic {
+  $ne: string | number | WhereLogic;
+  $in: Array<string | number> | Literal;
+  $not: boolean | string | number | WhereAttributeHash;
+  $notIn: Array<string | number> | Literal;
+  $gte: number | string | Date;
+  $gt: number | string | Date;
+  $lte: number | string | Date;
+  $lt: number | string | Date;
+  $like: string | WherePGStatement;
+  $iLike: string | WherePGStatement;
+  $ilike: string | WherePGStatement;
+  $notLike: string | WherePGStatement;
+  $notILike: string | WherePGStatement;
+  $between: [number, number];
+  '..': [number, number];
+  $notBetween: [number, number];
+  '!..': [number, number];
+  $overlap: [number, number];
+  '&&': [number, number];
+  $contains: any;
+  '@>': any;
+  $contained: any;
+  '<@': any;
+}
+
+/**
+ * A hash of attributes to describe your search. See above for examples.
+ *
+ * We did put Object in the end, because there where query might be a JSON Blob. It cripples a bit the
+ * typesafety, but there is no way to pass the tests if we just remove it.
+ */
+export interface WhereAttributeHash {
+  [field: string]: string | number | WhereLogic | WhereAttributeHash | Col | And | Or | WhereGeometryOptions | Array<string | number> | Object;
+}
+
+/**
+ * Through options for Include Options
+ */
+export interface IncludeThroughOptions {
+
+  /**
+   * Filter on the join model for belongsToMany relations
+   */
+  where?: WhereOptions;
+
+  /**
+   * A list of attributes to select from the join model for belongsToMany relations
+   */
+  attributes?: FindAttributeOptions;
+
+}
+
+export type Includeable = Model | Association | IncludeOptions;
+
+/**
+ * Complex include options
+ */
+export interface IncludeOptions {
+
+  /**
+   * The model you want to eagerly load
+   */
+  model?: typeof Model;
+
+  /**
+   * The alias of the relation, in case the model you want to eagerly load is aliassed. For `hasOne` /
+   * `belongsTo`, this should be the singular name, and for `hasMany`, it should be the plural
+   */
+  as?: string;
+
+  /**
+   * The association you want to eagerly load. (This can be used instead of providing a model/as pair)
+   */
+  association?: Association;
+
+  /**
+   * Where clauses to apply to the child models. Note that this converts the eager load to an inner join,
+   * unless you explicitly set `required: false`
+   */
+  where?: WhereOptions;
+
+  /**
+   * A list of attributes to select from the child model
+   */
+  attributes?: FindAttributeOptions;
+
+  /**
+   * If true, converts to an inner join, which means that the parent model will only be loaded if it has any
+   * matching children. True if `include.where` is set, false otherwise.
+   */
+  required?: boolean;
+
+  /**
+   * Through Options
+   */
+  through?: IncludeThroughOptions;
+
+  /**
+   * Load further nested related models
+   */
+  include?: Includeable[];
+
+}
+
+export type OrderItem =
+  string | Fn | Col | Literal |
+  [string | Col | Fn | Literal, string] |
+  [typeof Model | { model: typeof Model, as: string }, string, string] |
+  [typeof Model, typeof Model, string, string];
+export type Order = string | Fn | Col | Literal | OrderItem[];
+
+export type FindAttributeOptions =
+  Array<string | [string | Fn, string]> |
+  {
+    exclude: Array<string>;
+  } | {
+    exclude?: Array<string>;
+    include: Array<string | [string | Fn, string]>;
+  };
+
+export type WhereOptions = WhereAttributeHash | Array<Col | And | Or | string> | Where;
+
+/**
+ * Options that are passed to any model creating a SELECT query
+ *
+ * A hash of options to describe the scope of the search
+ */
+export interface FindOptions {
+  /**
+   * A hash of attributes to describe your search. See above for examples.
+   */
+  where?: WhereOptions;
+
+  /**
+   * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
+   * two elements - the first is the name of the attribute in the DB (or some kind of expression such as
+   * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
+   * have in the returned instance
+   */
+  attributes?: FindAttributeOptions;
+
+  /**
+   * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
+   * be returned. Only applies if `options.paranoid` is true for the model.
+   */
+  paranoid?: boolean;
+
+  /**
+   * A list of associations to eagerly load using a left join. Supported is either
+   * `{ include: [ Model1, Model2, ...]}` or `{ include: [{ model: Model1, as: 'Alias' }]}`.
+   * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
+   * the as attribute when eager loading Y).
+   */
+  include?: Includeable[];
+
+  /**
+   * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
+   * several columns / functions to order by. Each element can be further wrapped in a two-element array. The
+   * first element is the column / function to order by, the second is the direction. For example:
+   * `order: [['name', 'DESC']]`. In this way the column will be escaped, but the direction will not.
+   */
+  order?: Order;
+
+  /**
+   * GROUP BY in sql
+   */
+  group?: GroupOption;
+
+  /**
+   * Limit the results
+   */
+  limit?: number;
+
+  /**
+   * Skip the results;
+   */
+  offset?: number;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE.
+   * Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model
+   * locks with joins. See [transaction.LOCK for an example](transaction#lock)
+   */
+  lock?: string | { level: string, of: typeof Model };
+
+  /**
+   * Return raw result. See sequelize.query for more information.
+   */
+  raw?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * having ?!?
+   */
+  having?: WhereAttributeHash;
+
+}
+
+/**
+ * Options for Model.count method
+ */
+export interface CountOptions {
+
+  /**
+   * A hash of search attributes.
+   */
+  where?: WhereOptions;
+
+  /**
+   * Include options. See `find` for details
+   */
+  include?: Array<typeof Model | IncludeOptions>;
+
+  /**
+   * Apply COUNT(DISTINCT(col))
+   */
+  distinct?: boolean;
+
+  /**
+   * Used in conjustion with `group`
+   */
+  attributes?: FindAttributeOptions;
+
+  /**
+   * GROUP BY in sql
+   */
+  group?: GroupOption;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  transaction?: Transaction;
+}
+
+/**
+ * Options for Model.build method
+ */
+export interface BuildOptions {
+
+  /**
+   * If set to true, values will ignore field and virtual setters.
+   */
+  raw?: boolean;
+
+  /**
+   * Is this record new
+   */
+  isNewRecord?: boolean;
+
+  /**
+   * an array of include options - Used to build prefetched/included model instances. See `set`
+   *
+   * TODO: See set
+   */
+  include?: Includeable[];
+
+}
+
+/**
+ * Options for Model.create method
+ */
+export interface CreateOptions extends BuildOptions {
+
+  /**
+   * If set, only columns matching those in fields will be saved
+   */
+  fields?: Array<string>;
+
+  /**
+   * On Duplicate
+   */
+  onDuplicate?: string;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  silent?: boolean;
+
+  returning?: boolean;
+}
+
+/**
+ * Options for Model.findOrInitialize method
+ */
+export interface FindOrInitializeOptions {
+
+  /**
+   * A hash of search attributes.
+   */
+  where: WhereOptions;
+
+  /**
+   * Default values to use if building a new instance
+   */
+  defaults?: Object;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+}
+
+/**
+ * Options for Model.upsert method
+ */
+export interface UpsertOptions {
+  /**
+   * Run validations before the row is inserted
+   */
+  validate?: boolean;
+
+  /**
+   * The fields to insert / update. Defaults to all fields
+   */
+  fields?: Array<string>;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * An optional parameter to specify the schema search_path (Postgres only)
+   */
+  searchPath?: string;
+
+  /**
+   * Print query execution time in milliseconds when logging SQL.
+   */
+  benchmark?: boolean;
+}
+
+/**
+ * Options for Model.bulkCreate method
+ */
+export interface BulkCreateOptions {
+
+  /**
+   * Fields to insert (defaults to all fields)
+   */
+  fields?: Array<string>;
+
+  /**
+   * Should each row be subject to validation before it is inserted. The whole insert will fail if one row
+   * fails validation
+   */
+  validate?: boolean;
+
+  /**
+   * Run before / after bulk create hooks?
+   */
+  hooks?: boolean;
+
+  /**
+   * Run before / after create hooks for each individual Instance? BulkCreate hooks will still be run if
+   * options.hooks is true.
+   */
+  individualHooks?: boolean;
+
+  /**
+   * Ignore duplicate values for primary keys? (not supported by postgres)
+   *
+   * Defaults to false
+   */
+  ignoreDuplicates?: boolean;
+
+  /**
+   * Fields to update if row key already exists (on duplicate key update)? (only supported by mysql &
+   * mariadb). By default, all fields are updated.
+   */
+  updateOnDuplicate?: Array<string>;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+}
+
+/**
+ * The options passed to Model.destroy in addition to truncate
+ */
+export interface TruncateOptions {
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * Only used in conjuction with TRUNCATE. Truncates  all tables that have foreign-key references to the
+   * named table, or to any tables added to the group due to CASCADE.
+   *
+   * Defaults to false;
+   */
+  cascade?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+}
+
+/**
+ * Options used for Model.destroy
+ */
+export interface DestroyOptions extends TruncateOptions {
+
+  /**
+   * Filter the destroy
+   */
+  where?: WhereOptions;
+
+  /**
+   * Run before / after bulk destroy hooks?
+   */
+  hooks?: boolean;
+
+  /**
+   * If set to true, destroy will SELECT all records matching the where parameter and will execute before /
+   * after destroy hooks on each row
+   */
+  individualHooks?: boolean;
+
+  /**
+   * How many rows to delete
+   */
+  limit?: number;
+
+  /**
+   * Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
+   */
+  force?: boolean;
+
+  /**
+   * If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is
+   * truncated the where and limit options are ignored
+   */
+  truncate?: boolean;
+
+}
+
+/**
+ * Options for Model.restore
+ */
+export interface RestoreOptions {
+
+  /**
+   * Filter the restore
+   */
+  where?: WhereOptions;
+
+  /**
+   * Run before / after bulk restore hooks?
+   */
+  hooks?: boolean;
+
+  /**
+   * If set to true, restore will find all records within the where parameter and will execute before / after
+   * bulkRestore hooks on each row
+   */
+  individualHooks?: boolean;
+
+  /**
+   * How many rows to undelete
+   */
+  limit?: number;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+}
+
+/**
+ * Options used for Model.update
+ */
+export interface UpdateOptions {
+
+  /**
+   * Options to describe the scope of the search.
+   */
+  where: WhereOptions;
+
+  /**
+   * Fields to update (defaults to all fields)
+   */
+  fields?: Array<string>;
+
+  /**
+   * Should each row be subject to validation before it is inserted. The whole insert will fail if one row
+   * fails validation.
+   *
+   * Defaults to true
+   */
+  validate?: boolean;
+
+  /**
+   * Run before / after bulk update hooks?
+   *
+   * Defaults to true
+   */
+  hooks?: boolean;
+
+  /**
+   * Whether or not to update the side effects of any virtual setters.
+   *
+   * Defaults to true
+   */
+  sideEffects?: boolean;
+
+  /**
+   * Run before / after update hooks?. If true, this will execute a SELECT followed by individual UPDATEs.
+   * A select is needed, because the row data needs to be passed to the hooks
+   *
+   * Defaults to false
+   */
+  individualHooks?: boolean;
+
+  /**
+   * Return the affected rows (only for postgres)
+   */
+  returning?: boolean;
+
+  /**
+   * How many rows to update (only for mysql and mariadb)
+   */
+  limit?: number;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+}
+
+/**
+ * Options used for Model.aggregate
+ */
+export interface AggregateOptions extends QueryOptions {
+  /** A hash of search attributes. */
+  where?: WhereOptions;
+
+  /**
+   * The type of the result. If `field` is a field in this Model, the default will be the type of that field,
+   * otherwise defaults to float.
+   */
+  dataType?: DataType;
+
+  /** Applies DISTINCT to the field being aggregated over */
+  distinct?: boolean;
+}
+
+// instance
+
+
+/**
+ * Options used for Instance.increment method
+ */
+export interface IncrementDecrementOptions {
+
+  /**
+   * The number to increment by
+   *
+   * Defaults to 1
+   */
+  by?: number;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+  /**
+   * A hash of attributes to describe your search. See above for examples.
+   */
+  where?: WhereOptions;
+
+}
+
+/**
+ * Options used for Instance.restore method
+ */
+export interface InstanceRestoreOptions {
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run query under
+   */
+  transaction?: Transaction;
+
+}
+
+/**
+ * Options used for Instance.destroy method
+ */
+export interface InstanceDestroyOptions {
+
+  /**
+   * If set to true, paranoid models will actually be deleted
+   */
+  force?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run the query in
+   */
+  transaction?: Transaction;
+
+}
+
+/**
+ * Options used for Instance.update method
+ */
+export interface InstanceUpdateOptions extends SaveOptions, SetOptions {
+
+  /**
+   * A hash of attributes to describe your search. See above for examples.
+   */
+  where?: WhereOptions;
+
+}
+
+/**
+ * Options used for Instance.set method
+ */
+export interface SetOptions {
+
+  /**
+   * If set to true, field and virtual setters will be ignored
+   */
+  raw?: boolean;
+
+  /**
+   * Clear all previously set data values
+   */
+  reset?: boolean;
+
+}
+
+/**
+ * Options used for Instance.save method
+ */
+export interface SaveOptions {
+
+  /**
+   * An optional array of strings, representing database columns. If fields is provided, only those columns
+   * will be validated and saved.
+   */
+  fields?: Array<string>;
+
+  /**
+   * If true, the updatedAt timestamp will not be updated.
+   *
+   * Defaults to false
+   */
+  silent?: boolean;
+
+  /**
+   * If false, validations won't be run.
+   *
+   * Defaults to true
+   */
+  validate?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: boolean | Function;
+
+  /**
+   * Transaction to run the query in
+   */
+  transaction?: Transaction;
+}
+
+
+/**
+ * Model validations, allow you to specify format/content/inheritance validations for each attribute of the
+ * model.
+ *
+ * Validations are automatically run on create, update and save. You can also call validate() to manually
+ * validate an instance.
+ *
+ * The validations are implemented by validator.js.
+ */
+export interface ModelValidateOptions {
+
+  /**
+   * is: ["^[a-z]+$",'i'] // will only allow letters
+   * is: /^[a-z]+$/i      // same as the previous example using real RegExp
+   */
+  is?: string | Array<string | RegExp> | RegExp | { msg: string, args: string | Array<string | RegExp> | RegExp };
+
+  /**
+   * not: ["[a-z]",'i']  // will not allow letters
+   */
+  not?: string | Array<string | RegExp> | RegExp | { msg: string, args: string | Array<string | RegExp> | RegExp };
+
+  /**
+   * checks for email format (foo@bar.com)
+   */
+  isEmail?: boolean | { msg: string };
+
+  /**
+   * checks for url format (http://foo.com)
+   */
+  isUrl?: boolean | { msg: string };
+
+  /**
+   * checks for IPv4 (129.89.23.1) or IPv6 format
+   */
+  isIP?: boolean | { msg: string };
+
+  /**
+   * checks for IPv4 (129.89.23.1)
+   */
+  isIPv4?: boolean | { msg: string };
+
+  /**
+   * checks for IPv6 format
+   */
+  isIPv6?: boolean | { msg: string };
+
+  /**
+   * will only allow letters
+   */
+  isAlpha?: boolean | { msg: string };
+
+  /**
+   * will only allow alphanumeric characters, so "_abc" will fail
+   */
+  isAlphanumeric?: boolean | { msg: string };
+
+  /**
+   * will only allow numbers
+   */
+  isNumeric?: boolean | { msg: string };
+
+  /**
+   * checks for valid integers
+   */
+  isInt?: boolean | { msg: string };
+
+  /**
+   * checks for valid floating point numbers
+   */
+  isFloat?: boolean | { msg: string };
+
+  /**
+   * checks for any numbers
+   */
+  isDecimal?: boolean | { msg: string };
+
+  /**
+   * checks for lowercase
+   */
+  isLowercase?: boolean | { msg: string };
+
+  /**
+   * checks for uppercase
+   */
+  isUppercase?: boolean | { msg: string };
+
+  /**
+   * won't allow null
+   */
+  notNull?: boolean | { msg: string };
+
+  /**
+   * only allows null
+   */
+  isNull?: boolean | { msg: string };
+
+  /**
+   * don't allow empty strings
+   */
+  notEmpty?: boolean | { msg: string };
+
+  /**
+   * only allow a specific value
+   */
+  equals?: string | { msg: string };
+
+  /**
+   * force specific substrings
+   */
+  contains?: string | { msg: string };
+
+  /**
+   * check the value is not one of these
+   */
+  notIn?: Array<Array<string>> | { msg: string, args: Array<Array<string>> };
+
+  /**
+   * check the value is one of these
+   */
+  isIn?: Array<Array<string>> | { msg: string, args: Array<Array<string>> };
+
+  /**
+   * don't allow specific substrings
+   */
+  notContains?: Array<string> | string | { msg: string, args: Array<string> | string };
+
+  /**
+   * only allow values with length between 2 and 10
+   */
+  len?: [number, number] | { msg: string, args: [number, number] };
+
+  /**
+   * only allow uuids
+   */
+  isUUID?: number | { msg: string, args: number };
+
+  /**
+   * only allow date strings
+   */
+  isDate?: boolean | { msg: string, args: boolean };
+
+  /**
+   * only allow date strings after a specific date
+   */
+  isAfter?: string | { msg: string, args: string };
+
+  /**
+   * only allow date strings before a specific date
+   */
+  isBefore?: string | { msg: string, args: string };
+
+  /**
+   * only allow values
+   */
+  max?: number | { msg: string, args: number };
+
+  /**
+   * only allow values >= 23
+   */
+  min?: number | { msg: string, args: number };
+
+  /**
+   * only allow arrays
+   */
+  isArray?: boolean | { msg: string, args: boolean };
+
+  /**
+   * check for valid credit card numbers
+   */
+  isCreditCard?: boolean | { msg: string, args: boolean };
+
+  /**
+   * custom validations are also possible
+   *
+   * Implementation notes :
+   *
+   * We can't enforce any other method to be a function, so :
+   *
+   * ```typescript
+   * [name: string] : ( value : any ) => boolean;
+   * ```
+   *
+   * doesn't work in combination with the properties above
+   *
+   * @see https://github.com/Microsoft/TypeScript/issues/1889
+   */
+  [name: string]: any;
+
+}
+
+/**
+ * Interface for indexes property in DefineOptions
+ */
+export interface ModelIndexesOptions {
+
+  /**
+   * The name of the index. Defaults to model name + _ + fields concatenated
+   */
+  name?: string,
+
+  /**
+   * Index type. Only used by mysql. One of `UNIQUE`, `FULLTEXT` and `SPATIAL`
+   */
+  index?: string,
+
+  /**
+   * The method to create the index by (`USING` statement in SQL). BTREE and HASH are supported by mysql and
+   * postgres, and postgres additionally supports GIST and GIN.
+   */
+  method?: string,
+
+  /**
+   * Should the index by unique? Can also be triggered by setting type to `UNIQUE`
+   *
+   * Defaults to false
+   */
+  unique?: boolean,
+
+  /**
+   * PostgreSQL will build the index without taking any write locks. Postgres only
+   *
+   * Defaults to false
+   */
+  concurrently?: boolean,
+
+  /**
+   * An array of the fields to index. Each field can either be a string containing the name of the field,
+   * a sequelize object (e.g `sequelize.fn`), or an object with the following attributes: `attribute`
+   * (field name), `length` (create a prefix index of length chars), `order` (the direction the column
+   * should be sorted in), `collate` (the collation (sort order) for the column)
+   */
+  fields?: Array<string | { attribute: string, length: number, order: string, collate: string }>
+
+}
+
+/**
+ * Interface for name property in DefineOptions
+ */
+export interface ModelNameOptions {
+
+  /**
+   * Singular model name
+   */
+  singular?: string,
+
+  /**
+   * Plural model name
+   */
+  plural?: string,
+
+}
+
+/**
+ * Interface for getterMethods in DefineOptions
+ */
+export interface ModelGetterOptions {
+  [name: string]: () => any;
+}
+
+/**
+ * Interface for setterMethods in DefineOptions
+ */
+export interface ModelSetterOptions {
+  [name: string]: (val: any) => void;
+}
+
+/**
+ * Interface for Define Scope Options
+ */
+export interface ModelScopeOptions {
+
+  /**
+   * Name of the scope and it's query
+   */
+  [scopeName: string]: FindOptions | Function;
+
+}
+
+/**
+ * General column options
+ */
+export interface ColumnOptions {
+
+  /**
+   * If false, the column will have a NOT NULL constraint, and a not null validation will be run before an
+   * instance is saved.
+   */
+  allowNull?: boolean;
+
+  /**
+   *  If set, sequelize will map the attribute name to a different name in the database
+   */
+  field?: string;
+
+  /**
+   * A literal default value, a JavaScript function, or an SQL function (see `sequelize.fn`)
+   */
+  defaultValue?: any;
+
+}
+
+/**
+ * References options for the column's attributes
+ */
+export interface ModelAttributeColumnReferencesOptions {
+
+  /**
+   * If this column references another table, provide it here as a Model, or a string
+   */
+  model?: string | typeof Model;
+
+  /**
+   * The column of the foreign table that this column references
+   */
+  key?: string;
+
+  /**
+   * When to check for the foreign key constraing
+   *
+   * PostgreSQL only
+   */
+  deferrable?: AbstractDeferrable;
+
+}
+
+/**
+ * Column options for the model schema attributes
+ */
+export interface ModelAttributeColumnOptions extends ColumnOptions {
+
+  /**
+   * A string or a data type
+   */
+  type: DataType;
+
+  /**
+   * If true, the column will get a unique constraint. If a string is provided, the column will be part of a
+   * composite unique index. If multiple columns have the same string, they will be part of the same unique
+   * index
+   */
+  unique?: boolean | string | { name: string, msg: string };
+
+  /**
+   * Primary key flag
+   */
+  primaryKey?: boolean;
+
+  /**
+   * Is this field an auto increment field
+   */
+  autoIncrement?: boolean;
+
+  /**
+   * Comment for the database
+   */
+  comment?: string;
+
+  /**
+   * An object with reference configurations
+   */
+  references?: ModelAttributeColumnReferencesOptions;
+
+  /**
+   * What should happen when the referenced key is updated. One of CASCADE, RESTRICT, SET DEFAULT, SET NULL or
+   * NO ACTION
+   */
+  onUpdate?: string;
+
+  /**
+   * What should happen when the referenced key is deleted. One of CASCADE, RESTRICT, SET DEFAULT, SET NULL or
+   * NO ACTION
+   */
+  onDelete?: string;
+
+  /**
+   * Provide a custom getter for this column. Use `this.getDataValue(String)` to manipulate the underlying
+   * values.
+   */
+  get?: () => any;
+
+  /**
+   * Provide a custom setter for this column. Use `this.setDataValue(String, Value)` to manipulate the
+   * underlying values.
+   */
+  set?: (val: any) => void;
+
+  /**
+   * An object of validations to execute for this column every time the model is saved. Can be either the
+   * name of a validation provided by validator.js, a validation function provided by extending validator.js
+   * (see the
+   * `DAOValidator` property for more details), or a custom validation function. Custom validation functions
+   * are called with the value of the field, and can possibly take a second callback argument, to signal that
+   * they are asynchronous. If the validator is sync, it should throw in the case of a failed validation, it
+   * it is async, the callback should be called with the error text.
+   */
+  validate?: ModelValidateOptions;
+
+  /**
+   * Usage in object notation
+   *
+   * ```js
+   * sequelize.define('model', {
+   *     states: {
+   *       type:   Sequelize.ENUM,
+   *       values: ['active', 'pending', 'deleted']
+   *     }
+   *   })
+   * ```
+   */
+  values?: Array<string>;
+
+}
+
+/**
+ * Interface for Attributes provided for a column
+ */
+export interface ModelAttributes {
+
+  /**
+   * The description of a database column
+   */
+  [name: string]: DataType | ModelAttributeColumnOptions;
+}
+
+
+/**
+ * Options for Model.init. We mostly duplicate the Hooks here, since there is no way to combine the two
+ * interfaces.
+ *
+ * beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate,
+ * beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestroy and
+ * afterBulkUpdate.
+ */
+export interface HooksOptions {
+
+  beforeValidate?: (instance: Model, options: Object) => any;
+  afterValidate?: (instance: Model, options: Object) => any;
+  beforeCreate?: (attributes: Model, options: CreateOptions) => any;
+  afterCreate?: (attributes: Model, options: CreateOptions) => any;
+  beforeDestroy?: (instance: Model, options: InstanceDestroyOptions) => any;
+  beforeDelete?: (instance: Model, options: InstanceDestroyOptions) => any;
+  afterDestroy?: (instance: Model, options: InstanceDestroyOptions) => any;
+  afterDelete?: (instance: Model, options: InstanceDestroyOptions) => any;
+  beforeUpdate?: (instance: Model, options: InstanceUpdateOptions) => any;
+  afterUpdate?: (instance: Model, options: InstanceUpdateOptions) => any;
+  beforeBulkCreate?: (instances: Array<Model>, options: BulkCreateOptions) => any;
+  afterBulkCreate?: (instances: Array<Model>, options: BulkCreateOptions) => any;
+  beforeBulkDestroy?: (options: DestroyOptions) => any;
+  beforeBulkDelete?: (options: DestroyOptions) => any;
+  afterBulkDestroy?: (options: DestroyOptions) => any;
+  afterBulkDelete?: (options: DestroyOptions) => any;
+  beforeBulkUpdate?: (options: UpdateOptions) => any;
+  afterBulkUpdate?: (options: UpdateOptions) => any;
+  beforeFind?: (options: FindOptions) => any;
+  beforeFindAfterExpandIncludeAll?: (options: FindOptions) => any;
+  beforeFindAfterOptions?: (options: FindOptions) => any;
+  afterFind?: (instancesOrInstance: Array<Model> | Model, options: FindOptions) => any;
+  beforeSync?: (options: SyncOptions) => any;
+  afterSync?: (options: SyncOptions) => any;
+  beforeBulkSync?: (options: SyncOptions) => any;
+  afterBulkSync?: (options: SyncOptions) => any;
+}
+
+/**
+ * Options for model definition
+ */
+export interface ModelOptions {
+
+  /**
+   * Define the default search scope to use for this model. Scopes have the same form as the options passed to
+   * find / findAll.
+   */
+  defaultScope?: FindOptions;
+
+  /**
+   * More scopes, defined in the same way as defaultScope above. See `Model.scope` for more information about
+   * how scopes are defined, and what you can do with them
+   */
+  scopes?: ModelScopeOptions;
+
+  /**
+   * Don't persits null values. This means that all columns with null values will not be saved.
+   */
+  omitNull?: boolean;
+
+  /**
+   * Adds createdAt and updatedAt timestamps to the model. Default true.
+   */
+  timestamps?: boolean;
+
+  /**
+   * Calling destroy will not delete the model, but instead set a deletedAt timestamp if this is true. Needs
+   * timestamps=true to work. Default false.
+   */
+  paranoid?: boolean;
+
+  /**
+   * Converts all camelCased columns to underscored if true. Default false.
+   */
+  underscored?: boolean;
+
+  /**
+   * Converts camelCased model names to underscored tablenames if true. Default false.
+   */
+  underscoredAll?: boolean;
+
+  /**
+   * If freezeTableName is true, sequelize will not try to alter the DAO name to get the table name.
+   * Otherwise, the dao name will be pluralized. Default false.
+   */
+  freezeTableName?: boolean;
+
+  /**
+   * An object with two attributes, `singular` and `plural`, which are used when this model is associated to
+   * others.
+   */
+  name?: ModelNameOptions;
+
+  /**
+   * Indexes for the provided database table
+   */
+  indexes?: Array<ModelIndexesOptions>;
+
+  /**
+   * Override the name of the createdAt column if a string is provided, or disable it if false. Timestamps
+   * must be true. Not affected by underscored setting.
+   */
+  createdAt?: string | boolean;
+
+  /**
+   * Override the name of the deletedAt column if a string is provided, or disable it if false. Timestamps
+   * must be true. Not affected by underscored setting.
+   */
+  deletedAt?: string | boolean;
+
+  /**
+   * Override the name of the updatedAt column if a string is provided, or disable it if false. Timestamps
+   * must be true. Not affected by underscored setting.
+   */
+  updatedAt?: string | boolean;
+
+  /**
+   * Defaults to pluralized model name, unless freezeTableName is true, in which case it uses model name
+   * verbatim
+   */
+  tableName?: string;
+
+  /**
+   * Provide getter functions that work like those defined per column. If you provide a getter method with
+   * the
+   * same name as a column, it will be used to access the value of that column. If you provide a name that
+   * does not match a column, this function will act as a virtual getter, that can fetch multiple other
+   * values
+   */
+  getterMethods?: ModelGetterOptions;
+
+  /**
+   * Provide setter functions that work like those defined per column. If you provide a setter method with
+   * the
+   * same name as a column, it will be used to update the value of that column. If you provide a name that
+   * does not match a column, this function will act as a virtual setter, that can act on and set other
+   * values, but will not be persisted
+   */
+  setterMethods?: ModelSetterOptions;
+
+  /**
+   * Provide functions that are added to each instance (DAO). If you override methods provided by sequelize,
+   * you can access the original method using `this.constructor.super_.prototype`, e.g.
+   * `this.constructor.super_.prototype.toJSON.apply(this, arguments)`
+   */
+  instanceMethods?: Object;
+
+  /**
+   * Provide functions that are added to the model (Model). If you override methods provided by sequelize,
+   * you can access the original method using `this.constructor.prototype`, e.g.
+   * `this.constructor.prototype.find.apply(this, arguments)`
+   */
+  classMethods?: Object;
+
+  schema?: string;
+
+  /**
+   * You can also change the database engine, e.g. to MyISAM. InnoDB is the default.
+   */
+  engine?: string;
+
+  charset?: string;
+
+  /**
+   * Finaly you can specify a comment for the table in MySQL and PG
+   */
+  comment?: string;
+
+  collate?: string;
+
+  /**
+   * Set the initial AUTO_INCREMENT value for the table in MySQL.
+   */
+  initialAutoIncrement?: string;
+
+  /**
+   * An object of hook function that are called before and after certain lifecycle events.
+   * The possible hooks are: beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy,
+   * beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate,
+   * afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook
+   * functions and their signatures. Each property can either be a function, or an array of functions.
+   */
+  hooks?: HooksOptions;
+
+  /**
+   * An object of model wide validations. Validations have access to all model values via `this`. If the
+   * validator function takes an argument, it is asumed to be async, and is called with a callback that
+   * accepts an optional error.
+   */
+  validate?: ModelValidateOptions;
+
+}
+
+export abstract class Model {
+
+  /** The name of the database table */
+  static tableName: string;
+
+  /**
+   * Returns true if this instance has not yet been persisted to the database
+   */
+  isNewRecord: boolean;
+
+  /**
+   * A reference to the sequelize instance
+   */
+  sequelize: Sequelize;
+
+
+  static init(attributes: ModelAttributes, options: ModelOptions, modelManager: ModelManager): void;
+
+  /**
+   * Remove attribute from model definition
+   *
+   * @param attribute
+   */
+  static removeAttribute(attribute: string): void;
+
+  /**
+   * Sync this Model to the DB, that is create the table. Upon success, the callback will be called with the
+   * model instance (this)
+   */
+  static sync(options?: SyncOptions): Promise<Model>;
+
+  /**
+   * Drop the table represented by this Model
+   *
+   * @param options
+   */
+  static drop(options?: DropOptions): Promise<void>;
+
+  /**
+   * Apply a schema to this model. For postgres, this will actually place the schema in front of the table
+   * name
+   * - `"schema"."tableName"`, while the schema will be prepended to the table name for mysql and
+   * sqlite - `'schema.tablename'`.
+   *
+   * @param schema The name of the schema
+   * @param options
+   */
+  static schema(schema: string, options?: SchemaOptions): Model; // I would like to use `this` as return type here, but https://github.com/Microsoft/TypeScript/issues/5863
+
+  /**
+   * Get the tablename of the model, taking schema into account. The method will return The name as a string
+   * if the model has no schema, or an object with `tableName`, `schema` and `delimiter` properties.
+   *
+   * @param options The hash of options from any query. You can use one model to access tables with matching
+   *     schemas by overriding `getTableName` and using custom key/values to alter the name of the table.
+   *     (eg.
+   *     subscribers_1, subscribers_2)
+   * @param options.logging=false A function that gets executed while running the query to log the sql.
+   */
+  static getTableName(options?: { logging: Function }): string | Object;
+
+  /**
+   * Apply a scope created in `define` to the model. First let's look at how to create scopes:
+   * ```js
+   * var Model = sequelize.define('model', attributes, {
+   *   defaultScope: {
+   *     where: {
+   *       username: 'dan'
+   *     },
+   *     limit: 12
+   *   },
+   *   scopes: {
+   *     isALie: {
+   *       where: {
+   *         stuff: 'cake'
+   *       }
+   *     },
+   *     complexFunction: function(email, accessLevel) {
+   *       return {
+   *         where: {
+   *           email: {
+   *             $like: email
+   *           },
+   *           accesss_level {
+   *             $gte: accessLevel
+   *           }
+   *         }
+   *       }
+   *     }
+   *   }
+   * })
+   * ```
+   * Now, since you defined a default scope, every time you do Model.find, the default scope is appended to
+   * your query. Here's a couple of examples:
+   * ```js
+   * Model.findAll() // WHERE username = 'dan'
+   * Model.findAll({ where: { age: { gt: 12 } } }) // WHERE age > 12 AND username = 'dan'
+   * ```
+   *
+   * To invoke scope functions you can do:
+   * ```js
+   * Model.scope({ method: ['complexFunction' 'dan@sequelize.com', 42]}).findAll()
+   * // WHERE email like 'dan@sequelize.com%' AND access_level >= 42
+   * ```
+   *
+   * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
+   *     model will clear the previous scope.
+   */
+  static scope(options?: string | Array<string> | ScopeOptions | WhereAttributeHash): typeof Model;
+
+  /**
+   * Search for multiple instances.
+   *
+   * __Simple search using AND and =__
+   * ```js
+   * Model.findAll({
+   *   where: {
+   *     attr1: 42,
+   *     attr2: 'cake'
+   *   }
+   * })
+   * ```
+   * ```sql
+   * WHERE attr1 = 42 AND attr2 = 'cake'
+   * ```
+   *
+   * __Using greater than, less than etc.__
+   * ```js
+   *
+   * Model.findAll({
+   *   where: {
+   *     attr1: {
+   *       gt: 50
+   *     },
+   *     attr2: {
+   *       lte: 45
+   *     },
+   *     attr3: {
+   *       in: [1,2,3]
+   *     },
+   *     attr4: {
+   *       ne: 5
+   *     }
+   *   }
+   * })
+   * ```
+   * ```sql
+   * WHERE attr1 > 50 AND attr2 <= 45 AND attr3 IN (1,2,3) AND attr4 != 5
+   * ```
+   * Possible options are: `$ne, $in, $not, $notIn, $gte, $gt, $lte, $lt, $like, $ilike/$iLike, $notLike,
+   * $notILike, '..'/$between, '!..'/$notBetween, '&&'/$overlap, '@>'/$contains, '<@'/$contained`
+   *
+   * __Queries using OR__
+   * ```js
+   * Model.findAll({
+   *   where: Sequelize.and(
+   *     { name: 'a project' },
+   *     Sequelize.or(
+   *       { id: [1,2,3] },
+   *       { id: { gt: 10 } }
+   *     )
+   *   )
+   * })
+   * ```
+   * ```sql
+   * WHERE name = 'a project' AND (id` IN (1,2,3) OR id > 10)
+   * ```
+   *
+   * The success listener is called with an array of instances if the query succeeds.
+   *
+   * @see    {Sequelize#query}
+   */
+  static findAll(options?: FindOptions): Promise<Array<Model>>;
+  static all(optionz?: FindOptions): Promise<Array<Model>>;
+
+  /**
+   * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
+   * always be called with a single instance.
+   */
+  static findById(identifier?: number | string, options?: FindOptions): Promise<Model>;
+  static findByPrimary(identifier?: number | string, options?: FindOptions): Promise<Model>;
+
+  /**
+   * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
+   * instance.
+   */
+  static findOne(options?: FindOptions): Promise<Model>;
+  static find(optionz?: FindOptions): Promise<Model>;
+
+  /**
+   * Run an aggregation method on the specified field
+   *
+   * @param field The field to aggregate over. Can be a field name or *
+   * @param aggregateFunction The function to use for aggregation, e.g. sum, max etc.
+   * @param options Query options. See sequelize.query for full options
+   * @return Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in
+   *     which case the complete data result is returned.
+   */
+  aggregate<T>(field: string, aggregateFunction: string, options?: AggregateOptions): Promise<T>;
+  static aggregate(field: string, aggregateFunction: string, options?: AggregateOptions): Promise<number>;
+
+  /**
+   * Count the number of records matching the provided where clause.
+   *
+   * If you provide an `include` option, the number of matching associations will be counted instead.
+   */
+  static count(options?: CountOptions): Promise<number>;
+
+  /**
+   * Find all the rows matching your query, within a specified offset / limit, and get the total number of
+   * rows matching your query. This is very usefull for paging
+   *
+   * ```js
+   * Model.findAndCountAll({
+   *   where: ...,
+   *   limit: 12,
+   *   offset: 12
+   * }).then(function (result) {
+   *   ...
+   * })
+   * ```
+   * In the above example, `result.rows` will contain rows 13 through 24, while `result.count` will return
+   * the
+   * total number of rows that matched your query.
+   *
+   * When you add includes, only those which are required (either because they have a where clause, or
+   * because
+   * `required` is explicitly set to true on the include) will be added to the count part.
+   *
+   * Suppose you want to find all users who have a profile attached:
+   * ```js
+   * User.findAndCountAll({
+   *   include: [
+   *      { model: Profile, required: true}
+   *   ],
+   *   limit 3
+   * });
+   * ```
+   * Because the include for `Profile` has `required` set it will result in an inner join, and only the users
+   * who have a profile will be counted. If we remove `required` from the include, both users with and
+   * without
+   * profiles will be counted
+   */
+  static findAndCount(options?: FindOptions): Promise<{ rows: Array<Model>, count: number }>;
+  static findAndCountAll(options?: FindOptions): Promise<{ rows: Array<Model>, count: number }>;
+
+  /**
+   * Find the maximum value of field
+   */
+  static max(field: string, options?: AggregateOptions): Promise<any>;
+
+  /**
+   * Find the minimum value of field
+   */
+  static min(field: string, options?: AggregateOptions): Promise<any>;
+
+  /**
+   * Find the sum of field
+   */
+  static sum(field: string, options?: AggregateOptions): Promise<number>;
+
+  /**
+   * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
+   */
+  static build(record?: Object, options?: BuildOptions): Model;
+
+  /**
+   * Undocumented bulkBuild
+   */
+  static bulkBuild(records: Object[], options?: BuildOptions): Array<Model>;
+
+  /**
+   * Builds a new model instance and calls save on it.
+   */
+  static create(values?: Object, options?: CreateOptions): Promise<Model>;
+
+  /**
+   * Find a row that matches the query, or build (but don't save) the row if none is found.
+   * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
+   */
+  static findOrInitialize(options: FindOrInitializeOptions): Promise<Model>;
+  static findOrBuild(options: FindOrInitializeOptions): Promise<Model>;
+
+  /**
+   * Find a row that matches the query, or build and save the row if none is found
+   * The successful result of the promise will be (instance, created) - Make sure to use .spread()
+   *
+   * If no transaction is passed in the `options` object, a new transaction will be created internally, to
+   * prevent the race condition where a matching row is created by another connection after the find but
+   * before the insert call. However, it is not always possible to handle this case in SQLite, specifically
+   * if one transaction inserts and another tries to select before the first one has comitted. In this case,
+   * an instance of sequelize.TimeoutError will be thrown instead. If a transaction is created, a savepoint
+   * will be created instead, and any unique constraint violation will be handled internally.
+   */
+  static findOrCreate(options: FindOrInitializeOptions): Promise<Model>;
+
+  /**
+   * Insert or update a single row. An update will be executed if a row which matches the supplied values on
+   * either the primary key or a unique key is found. Note that the unique index must be defined in your
+   * sequelize model and not just in the table. Otherwise you may experience a unique constraint violation,
+   * because sequelize fails to identify the row that should be updated.
+   *
+   * **Implementation details:**
+   *
+   * * MySQL - Implemented as a single query `INSERT values ON DUPLICATE KEY UPDATE values`
+   * * PostgreSQL - Implemented as a temporary function with exception handling: INSERT EXCEPTION WHEN
+   *   unique_constraint UPDATE
+   * * SQLite - Implemented as two queries `INSERT; UPDATE`. This means that the update is executed
+   * regardless
+   *   of whether the row already existed or not
+   *
+   * **Note** that SQLite returns undefined for created, no matter if the row was created or updated. This is
+   * because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know
+   * whether the row was inserted or not.
+   */
+  static upsert(values: Object, options?: UpsertOptions): Promise<boolean>;
+  static insertOrUpdate(values: Object, options?: UpsertOptions): Promise<boolean>;
+
+  /**
+   * Create and insert multiple instances in bulk.
+   *
+   * The success handler is passed an array of instances, but please notice that these may not completely
+   * represent the state of the rows in the DB. This is because MySQL and SQLite do not make it easy to
+   * obtain
+   * back automatically generated IDs and other default values in a way that can be mapped to multiple
+   * records. To obtain Instances for the newly created values, you will need to query for them again.
+   *
+   * @param records List of objects (key/value pairs) to create instances from
+   */
+  static bulkCreate(records: Array<Object>, options?: BulkCreateOptions): Promise<Array<Model>>;
+
+  /**
+   * Truncate all instances of the model. This is a convenient method for Model.destroy({ truncate: true }).
+   */
+  static truncate(options?: TruncateOptions): Promise<void>;
+
+  /**
+   * Delete multiple instances, or set their deletedAt timestamp to the current time if `paranoid` is enabled.
+   *
+   * @return Promise<number> The number of destroyed rows
+   */
+  static destroy(options?: DestroyOptions): Promise<number>;
+
+  /**
+   * Restore multiple instances if `paranoid` is enabled.
+   */
+  static restore(options?: RestoreOptions): Promise<void>;
+
+  /**
+   * Update multiple instances that match the where options. The promise returns an array with one or two
+   * elements. The first element is always the number of affected rows, while the second element is the actual
+   * affected rows (only supported in postgres with `options.returning` true.)
+   */
+  static update(values: Object, options: UpdateOptions): Promise<[number, Array<Model>]>;
+
+  /**
+   * Run a describe query on the table. The result will be return to the listener as a hash of attributes and
+   * their types.
+   */
+  static describe(): Promise<Object>;
+
+  /**
+   * Unscope the model
+   */
+  static unscoped(): typeof Model;
+
+  /**
+   * Add a hook to the model
+   *
+   * @param hookType
+   * @param name Provide a name for the hook function. It can be used to remove the hook later or to order
+   *     hooks based on some sort of priority system in the future.
+   * @param fn The hook function
+   *
+   * @alias hook
+   */
+  static addHook(hookType: string, name: string, fn: Function): typeof Model;
+  static addHook(hookType: string, fn: Function): typeof Model;
+  static hook(hookType: string, name: string, fn: Function): typeof Model;
+  static hook(hookType: string, fn: Function): typeof Model;
+
+  /**
+   * Remove hook from the model
+   *
+   * @param hookType
+   * @param name
+   */
+  static removeHook(hookType: string, name: string): typeof Model;
+
+  /**
+   * Check whether the mode has any hooks of this type
+   *
+   * @param hookType
+   *
+   * @alias hasHooks
+   */
+  static hasHook(hookType: string): boolean;
+  static hasHooks(hookType: string): boolean;
+
+  /**
+   * A hook that is run before validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static beforeValidate(name: string, fn: (instance: Model, options: Object) => void): void;
+  static beforeValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run after validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static afterValidate(name: string,
+    fn: (instance: Model, options: Object) => void): void;
+  static afterValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run before creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  static beforeCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  static beforeCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  static afterCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  static afterCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias beforeDelete
+   */
+  static beforeDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias afterDelete
+   */
+  static afterDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run before updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static beforeUpdate(name: string,
+    fn: (instance: Model, options: UpdateOptions) => void): void;
+  static beforeUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static afterUpdate(name: string, fn: (instance: Model, options: UpdateOptions) => void): void;
+  static afterUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   */
+  static beforeBulkCreate(name: string,
+    fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  static beforeBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   * @name afterBulkCreate
+   */
+  static afterBulkCreate(name: string, fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  static afterBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias beforeBulkDelete
+   */
+  static beforeBulkDestroy(name: string, fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDestroy(fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDelete(name: string, fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDelete(fn: (options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias afterBulkDelete
+   */
+  static afterBulkDestroy(name: string, fn: (options: DestroyOptions) => void): void;
+  static afterBulkDestroy(fn: (options: DestroyOptions) => void): void;
+  static afterBulkDelete(name: string, fn: (options: DestroyOptions) => void): void;
+  static afterBulkDelete(fn: (options: DestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  static beforeBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static afterBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  static afterBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFind(name: string, fn: (options: FindOptions) => void): void;
+  static beforeFind(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFindAfterExpandIncludeAll(name: string,
+    fn: (options: FindOptions) => void): void;
+  static beforeFindAfterExpandIncludeAll(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after all option parsing is complete
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFindAfterOptions(name: string, fn: (options: FindOptions) => void): void;
+  static beforeFindAfterOptions(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run after a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with instance(s), options
+   */
+  static afterFind(name: string, fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+  static afterFind(fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+
+  /**
+   * A hook that is run before a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with attributes, options
+   */
+  static beforeDefine(name: string, fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+  static beforeDefine(fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+
+  /**
+   * A hook that is run after a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with factory
+   */
+  static afterDefine(name: string, fn: (model: typeof Model) => void): void;
+  static afterDefine(fn: (model: typeof Model) => void): void;
+
+  /**
+   * A hook that is run before Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with config, options
+   */
+  static beforeInit(name: string, fn: (config: Object, options: Object) => void): void;
+  static beforeInit(fn: (config: Object, options: Object) => void): void;
+
+  /**
+   * A hook that is run after Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with sequelize
+   */
+  static afterInit(name: string, fn: (sequelize: Sequelize) => void): void;
+  static afterInit(fn: (sequelize: Sequelize) => void): void;
+
+  /**
+   * A hook that is run before sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name beforeBulkSync
+   */
+  static beforeBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  static beforeBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name afterBulkSync
+   */
+  static afterBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  static afterBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run before Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name beforeSync
+   */
+  static beforeSync(name: string, fn: (options: SyncOptions) => any): void;
+  static beforeSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name afterSync
+   */
+  static afterSync(name: string, fn: (options: SyncOptions) => any): void;
+  static afterSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * Creates an association between this (the source) and the provided target. The foreign key is added
+   * on the target.
+   *
+   * Example: `User.hasOne(Profile)`. This will add userId to the profile table.
+   *
+   * @param target The model that will be associated with hasOne relationship
+   * @param options Options for the association
+   */
+  static hasOne(target: typeof Model, options?: HasOneOptions): HasOne;
+
+  /**
+   * Creates an association between this (the source) and the provided target. The foreign key is added on the
+   * source.
+   *
+   * Example: `Profile.belongsTo(User)`. This will add userId to the profile table.
+   *
+   * @param target The model that will be associated with hasOne relationship
+   * @param options Options for the association
+   */
+  static belongsTo(target: typeof Model, options?: BelongsToOptions): BelongsTo;
+
+  /**
+   * Create an association that is either 1:m or n:m.
+   *
+   * ```js
+   * // Create a 1:m association between user and project
+   * User.hasMany(Project)
+   * ```
+   * ```js
+   * // Create a n:m association between user and project
+   * User.hasMany(Project)
+   * Project.hasMany(User)
+   * ```
+   * By default, the name of the join table will be source+target, so in this case projectsusers. This can be
+   * overridden by providing either a string or a Model as `through` in the options. If you use a through
+   * model with custom attributes, these attributes can be set when adding / setting new associations in two
+   * ways. Consider users and projects from before with a join table that stores whether the project has been
+   * started yet:
+   * ```js
+   * var UserProjects = sequelize.define('userprojects', {
+   *   started: Sequelize.BOOLEAN
+   * })
+   * User.hasMany(Project, { through: UserProjects })
+   * Project.hasMany(User, { through: UserProjects })
+   * ```
+   * ```js
+   * jan.addProject(homework, { started: false }) // The homework project is not started yet
+   * jan.setProjects([makedinner, doshopping], { started: true}) // Both shopping and dinner have been
+   * started
+   * ```
+   *
+   * If you want to set several target instances, but with different attributes you have to set the
+   * attributes on the instance, using a property with the name of the through model:
+   *
+   * ```js
+   * p1.userprojects {
+   *   started: true
+   * }
+   * user.setProjects([p1, p2], {started: false}) // The default value is false, but p1 overrides that.
+   * ```
+   *
+   * Similarily, when fetching through a join table with custom attributes, these attributes will be
+   * available as an object with the name of the through model.
+   * ```js
+   * user.getProjects().then(function (projects) {
+   *   var p1 = projects[0]
+   *   p1.userprojects.started // Is this project started yet?
+   * })
+   * ```
+   *
+   * @param target The model that will be associated with hasOne relationship
+   * @param options Options for the association
+   */
+  static hasMany(target: typeof Model, options?: HasManyOptions): HasMany;
+
+  /**
+   * Create an N:M association with a join table
+   *
+   * ```js
+   * User.belongsToMany(Project)
+   * Project.belongsToMany(User)
+   * ```
+   * By default, the name of the join table will be source+target, so in this case projectsusers. This can be
+   * overridden by providing either a string or a Model as `through` in the options.
+   *
+   * If you use a through model with custom attributes, these attributes can be set when adding / setting new
+   * associations in two ways. Consider users and projects from before with a join table that stores whether
+   * the project has been started yet:
+   * ```js
+   * var UserProjects = sequelize.define('userprojects', {
+   *   started: Sequelize.BOOLEAN
+   * })
+   * User.belongsToMany(Project, { through: UserProjects })
+   * Project.belongsToMany(User, { through: UserProjects })
+   * ```
+   * ```js
+   * jan.addProject(homework, { started: false }) // The homework project is not started yet
+   * jan.setProjects([makedinner, doshopping], { started: true}) // Both shopping and dinner has been started
+   * ```
+   *
+   * If you want to set several target instances, but with different attributes you have to set the
+   * attributes on the instance, using a property with the name of the through model:
+   *
+   * ```js
+   * p1.userprojects {
+   *   started: true
+   * }
+   * user.setProjects([p1, p2], {started: false}) // The default value is false, but p1 overrides that.
+   * ```
+   *
+   * Similarily, when fetching through a join table with custom attributes, these attributes will be
+   * available as an object with the name of the through model.
+   * ```js
+   * user.getProjects().then(function (projects) {
+   *   var p1 = projects[0]
+   *   p1.userprojects.started // Is this project started yet?
+   * })
+   * ```
+   *
+   * @param target The model that will be associated with hasOne relationship
+   * @param options Options for the association
+   *
+   */
+  static belongsToMany(target: typeof Model, options: BelongsToManyOptions): BelongsToMany;
+
+  /**
+   * Builds a new model instance.
+   * @param values an object of key value pairs
+   */
+  constructor(values?: Object, options?: BuildOptions);
+
+  /**
+   * Get an object representing the query for this instance, use with `options.where`
+   */
+  where(): Object;
+
+  /**
+   * Get the value of the underlying data value
+   */
+  getDataValue(key: string): any;
+
+  /**
+   * Update the underlying data value
+   */
+  setDataValue(key: string, value: any): void;
+
+  /**
+   * If no key is given, returns all values of the instance, also invoking virtual getters.
+   *
+   * If key is given and a field or virtual getter is present for the key it will call that getter - else it
+   * will return the value for key.
+   *
+   * @param options.plain If set to true, included instances will be returned as plain objects
+   */
+  get(options?: { plain?: boolean, clone?: boolean }): any;
+  get(key: string, options?: { plain?: boolean, clone?: boolean }): any;
+
+  /**
+   * Set is used to update values on the instance (the sequelize representation of the instance that is,
+   * remember that nothing will be persisted before you actually call `save`). In its most basic form `set`
+   * will update a value stored in the underlying `dataValues` object. However, if a custom setter function
+   * is defined for the key, that function will be called instead. To bypass the setter, you can pass `raw:
+   * true` in the options object.
+   *
+   * If set is called with an object, it will loop over the object, and call set recursively for each key,
+   * value pair. If you set raw to true, the underlying dataValues will either be set directly to the object
+   * passed, or used to extend dataValues, if dataValues already contain values.
+   *
+   * When set is called, the previous value of the field is stored and sets a changed flag(see `changed`).
+   *
+   * Set can also be used to build instances for associations, if you have values for those.
+   * When using set with associations you need to make sure the property key matches the alias of the
+   * association while also making sure that the proper include options have been set (from .build() or
+   * .find())
+   *
+   * If called with a dot.seperated key on a JSON/JSONB attribute it will set the value nested and flag the
+   * entire object as changed.
+   *
+   * @param options.raw If set to true, field and virtual setters will be ignored
+   * @param options.reset Clear all previously set data values
+   */
+  set(key: string, value: any, options?: SetOptions): Model;
+  set(keys: Object, options?: SetOptions): Model;
+  setAttributes(key: string, value: any, options?: SetOptions): Model;
+  setAttributes(keys: Object, options?: SetOptions): Model;
+
+  /**
+   * If changed is called with a string it will return a boolean indicating whether the value of that key in
+   * `dataValues` is different from the value in `_previousDataValues`.
+   *
+   * If changed is called without an argument, it will return an array of keys that have changed.
+   *
+   * If changed is called without an argument and no keys have changed, it will return `false`.
+   */
+  changed(key: string): boolean;
+  changed(): boolean | Array<string>;
+
+  /**
+   * Returns the previous value for key from `_previousDataValues`.
+   */
+  previous(key: string): any;
+
+  /**
+   * Validate this instance, and if the validation passes, persist it to the database.
+   *
+   * On success, the callback will be called with this instance. On validation error, the callback will be
+   * called with an instance of `Sequelize.ValidationError`. This error will have a property for each of the
+   * fields for which validation failed, with the error message for that field.
+   */
+  save(options?: SaveOptions): Promise<Model>;
+
+  /**
+   * Refresh the current instance in-place, i.e. update the object with current data from the DB and return
+   * the same object. This is different from doing a `find(Instance.id)`, because that would create and
+   * return a new instance. With this method, all references to the Instance are updated with the new data
+   * and no new objects are created.
+   */
+  reload(options?: FindOptions): Promise<Model>;
+
+  /**
+   * Validate the attribute of this instance according to validation rules set in the model definition.
+   *
+   * Emits null if and only if validation successful; otherwise an Error instance containing
+   * { field name : [error msgs] } entries.
+   *
+   * @param options.skip An array of strings. All properties that are in this array will not be validated
+   */
+  validate(options?: { skip?: Array<string> }): Promise<void>;
+
+  /**
+   * This is the same as calling `set` and then calling `save`.
+   */
+  update(key: string, value: any, options?: InstanceUpdateOptions): Promise<Model>;
+  update(keys: Object, options?: InstanceUpdateOptions): Promise<Model>;
+  updateAttributes(key: string, value: any, options?: InstanceUpdateOptions): Promise<Model>;
+  updateAttributes(keys: Object, options?: InstanceUpdateOptions): Promise<Model>;
+
+  /**
+   * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will
+   * either be completely deleted, or have its deletedAt timestamp set to the current time.
+   */
+  destroy(options?: InstanceDestroyOptions): Promise<void>;
+
+  /**
+   * Restore the row corresponding to this instance. Only available for paranoid models.
+   */
+  restore(options?: InstanceRestoreOptions): Promise<void>;
+
+  /**
+   * Increment the value of one or more columns. This is done in the database, which means it does not use
+   * the values currently stored on the Instance. The increment is done using a
+   * ```sql
+   * SET column = column + X
+   * ```
+   * query. To get the correct value after an increment into the Instance you should do a reload.
+   *
+   * ```js
+   * instance.increment('number') // increment number by 1
+   * instance.increment(['number', 'count'], { by: 2 }) // increment number and count by 2
+   * instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42, and tries by 1.
+   *                                                        // `by` is ignored, since each column has its own
+   *                                                        // value
+   * ```
+   *
+   * @param fields If a string is provided, that column is incremented by the value of `by` given in options.
+   *               If an array is provided, the same is true for each column.
+   *               If and object is provided, each column is incremented by the value given.
+   */
+  increment(fields: string | Array<string> | Object,
+    options?: IncrementDecrementOptions): Promise<Model>;
+
+  /**
+   * Decrement the value of one or more columns. This is done in the database, which means it does not use
+   * the values currently stored on the Instance. The decrement is done using a
+   * ```sql
+   * SET column = column - X
+   * ```
+   * query. To get the correct value after an decrement into the Instance you should do a reload.
+   *
+   * ```js
+   * instance.decrement('number') // decrement number by 1
+   * instance.decrement(['number', 'count'], { by: 2 }) // decrement number and count by 2
+   * instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42, and tries by 1.
+   *                                                        // `by` is ignored, since each column has its own
+   *                                                        // value
+   * ```
+   *
+   * @param fields If a string is provided, that column is decremented by the value of `by` given in options.
+   *               If an array is provided, the same is true for each column.
+   *               If and object is provided, each column is decremented by the value given
+   */
+  decrement(fields: string | Array<string> | Object,
+    options?: IncrementDecrementOptions): Promise<Model>;
+
+  /**
+   * Check whether all values of this and `other` Instance are the same
+   */
+  equals(other: Model): boolean;
+
+  /**
+   * Check if this is eqaul to one of `others` by calling equals
+   */
+  equalsOneOf(others: Model[]): boolean;
+
+  /**
+   * Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all
+   * values gotten from the DB, and apply all custom getters.
+   */
+  toJSON(): Object;
+}
+
+export default Model;

--- a/4/lib/promise.d.ts
+++ b/4/lib/promise.d.ts
@@ -1,0 +1,15 @@
+import * as Bluebird from 'bluebird';
+
+/**
+ * A slightly modified version of bluebird promises. This means that, on top of the methods below, you can also call all the methods listed on the link below.
+ *
+ * The main difference is that sequelize promises allows you to attach a listener that will be called with the generated SQL, each time a query is run.
+ *
+ * The sequelize promise class works seamlessly with other A+/thenable libraries, with one exception.
+ * If you want to propagate SQL events across then, all calls etc., you must use sequelize promises exclusively.
+ */
+export class Promise<T> extends Bluebird<T> {
+  sql(fct: (sql: string) => void): void;
+}
+
+export default Promise;

--- a/4/lib/query-interface.d.ts
+++ b/4/lib/query-interface.d.ts
@@ -1,0 +1,422 @@
+
+import {Sequelize} from './sequelize';
+import {Promise} from './promise';
+import {ModelAttributes, ModelAttributeColumnOptions, Model} from './model';
+import {Transaction} from './transaction';
+import {DataType} from './data-types';
+
+/**
+ * Interface for query options
+ */
+export interface QueryOptions {
+
+  /**
+   * If true, sequelize will not try to format the results of the query, or build an instance of a model from
+   * the result
+   */
+  raw?: boolean;
+
+  /**
+   * The transaction that the query should be executed under
+   */
+  transaction?: Transaction;
+
+  /**
+   * The type of query you are executing. The query type affects how results are formatted before they are
+   * passed back. The type is a string, but `Sequelize.QueryTypes` is provided as convenience shortcuts.
+   */
+  type?: string;
+
+  /**
+   * If true, transforms objects with `.` separated property names into nested objects using
+   * [dottie.js](https://github.com/mickhansen/dottie.js). For example { 'user.username': 'john' } becomes
+   * { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`,
+   * unless otherwise specified
+   *
+   * Defaults to false
+   */
+  nest?: boolean;
+
+  /**
+   * Sets the query type to `SELECT` and return a single row
+   */
+  plain?: boolean;
+
+  /**
+   * Either an object of named parameter replacements in the format `:param` or an array of unnamed
+   * replacements to replace `?` in your SQL.
+   */
+  replacements?: Object | Array<string>;
+
+  /**
+   * Force the query to use the write pool, regardless of the query type.
+   *
+   * Defaults to false
+   */
+  useMaster?: boolean;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: Function
+
+  /**
+   * A sequelize instance used to build the return instance
+   */
+  instance?: Model;
+
+  /**
+   * A sequelize model used to build the returned model instances (used to be called callee)
+   */
+  model?: typeof Model;
+
+  // TODO: force, cascade
+
+}
+
+/**
+  * Most of the methods accept options and use only the logger property of the options. That's why the most used
+  * interface type for options in a method is separated here as another interface.
+  */
+export interface QueryInterfaceOptions {
+
+  /**
+    * A function that gets executed while running the query to log the sql.
+    */
+  logging?: boolean | Function;
+
+}
+
+export interface QueryInterfaceCreateTableOptions extends QueryInterfaceOptions {
+  engine?: string;
+  charset?: string;
+}
+
+export interface QueryInterfaceDropTableOptions extends QueryInterfaceOptions {
+  cascade?: boolean;
+  force?: boolean;
+}
+
+export interface QueryInterfaceDropAllTablesOptions extends QueryInterfaceOptions {
+  skip?: string[];
+}
+
+export interface QueryInterfaceIndexOptions extends QueryInterfaceOptions {
+  indicesType?: 'UNIQUE'|'FULLTEXT'|'SPATIAL';
+
+  /** The name of the index. Default is __ */
+  indexName?: string;
+
+  /** For FULLTEXT columns set your parser */
+  parser?: string;
+
+  /** Set a type for the index, e.g. BTREE. See the documentation of the used dialect */
+  indexType?: string;
+}
+
+/**
+ * The interface that Sequelize uses to talk to all databases.
+ *
+ * This interface is available through sequelize.QueryInterface. It should not be commonly used, but it's
+ * referenced anyway, so it can be used.
+ */
+export class QueryInterface {
+
+  /**
+   * Returns the dialect-specific sql generator.
+   *
+   * We don't have a definition for the QueryGenerator, because I doubt it is commonly in use separately.
+   */
+  QueryGenerator: any;
+
+  /**
+   * Returns the current sequelize instance.
+   */
+  sequelize: Sequelize;
+
+  constructor(sequelize: Sequelize);
+
+  /**
+   * Queries the schema (table list).
+   *
+   * @param schema The schema to query. Applies only to Postgres.
+   */
+  createSchema(schema?: string, options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Drops the specified schema (table).
+   *
+   * @param schema The schema to query. Applies only to Postgres.
+   */
+  dropSchema(schema?: string, options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Drops all tables.
+   */
+  dropAllSchemas(options?: QueryInterfaceDropAllTablesOptions): Promise<void>;
+
+  /**
+   * Queries all table names in the database.
+   *
+   * @param options
+   */
+  showAllSchemas(options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Return database version
+   */
+  databaseVersion(options?: QueryInterfaceOptions): Promise<string>;
+
+  /**
+   * Creates a table with specified attributes.
+   *
+   * @param tableName     Name of table to create
+   * @param attributes    Hash of attributes, key is attribute name, value is data type
+   * @param options       Table options.
+   */
+  createTable(tableName: string | { schema?: string, tableName?: string }, attributes: ModelAttributes,
+    options?: QueryInterfaceCreateTableOptions): Promise<void>;
+
+  /**
+   * Drops the specified table.
+   *
+   * @param tableName Table name.
+   * @param options   Query options, particularly "force".
+   */
+  dropTable(tableName: string, options?: QueryInterfaceDropTableOptions): Promise<void>;
+
+  /**
+   * Drops all tables.
+   *
+   * @param options
+   */
+  dropAllTables(options?: QueryInterfaceDropTableOptions): Promise<void>;
+
+  /**
+   * Drops all defined enums
+   *
+   * @param options
+   */
+  dropAllEnums(options?: QueryOptions): Promise<void>;
+
+  /**
+   * Renames a table
+   */
+  renameTable(before: string, after: string, options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Returns all tables
+   */
+  showAllTables(options?: QueryOptions): Promise<Array<string>>;
+
+  /**
+   * Describe a table
+   */
+  describeTable(tableName: string | { schema?: string, tableName?: string },
+    options?: string | { schema?: string, schemaDelimeter?: string, logging?: boolean | Function }): Promise<Object>;
+
+  /**
+   * Adds a new column to a table
+   */
+  addColumn(table: string, key: string, attribute: ModelAttributeColumnOptions | DataType,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Removes a column from a table
+   */
+  removeColumn(table: string, attribute: string, options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Changes a column
+   */
+  changeColumn(tableName: string | { schema?: string, tableName?: string }, attributeName: string,
+    dataTypeOrOptions?: DataType | ModelAttributeColumnOptions,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Renames a column
+   */
+  renameColumn(tableName: string | { schema?: string, tableName?: string }, attrNameBefore: string,
+    attrNameAfter: string,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Adds a new index to a table
+   */
+  addIndex(tableName: string, attributes: string[], options?: QueryInterfaceIndexOptions,
+    rawTablename?: string): Promise<void>;
+  addIndex(tableName: string, options: QueryInterfaceIndexOptions & { fields: string[] },
+    rawTablename?: string): Promise<void>;
+
+  /**
+   * Removes an index of a table
+   */
+  removeIndex(tableName: string, indexName: string,
+    options?: QueryInterfaceIndexOptions): Promise<void>;
+  removeIndex(tableName: string, attributes: string[],
+    options?: QueryInterfaceIndexOptions): Promise<void>;
+
+  /**
+   * Shows the index of a table
+   */
+  showIndex(tableName: string | Object, options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Put a name to an index
+   */
+  nameIndexes(indexes: Array<string>, rawTablename: string): Promise<void>;
+
+  /**
+   * Returns all foreign key constraints of a table
+   */
+  getForeignKeysForTables(tableNames: string, options?: QueryInterfaceOptions): Promise<Object>;
+
+  /**
+   * Inserts a new record
+   */
+  insert(instance: Model, tableName: string, values: Object,
+    options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Inserts or Updates a record in the database
+   */
+  upsert(tableName: string, values: Object, updateValues: Object, model: typeof Model,
+    options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Inserts multiple records at once
+   */
+  bulkInsert(tableName: string, records: Array<Object>, options?: QueryOptions,
+    attributes?: Array<string> | string): Promise<Object>;
+
+  /**
+   * Updates a row
+   */
+  update(instance: Model, tableName: string, values: Object, identifier: Object,
+    options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Updates multiple rows at once
+   */
+  bulkUpdate(tableName: string, values: Object, identifier: Object, options?: QueryOptions,
+    attributes?: Array<string> | string): Promise<Object>;
+
+  /**
+   * Deletes a row
+   */
+  delete(instance: Model, tableName: string, identifier: Object,
+    options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Deletes multiple rows at once
+   */
+  bulkDelete(tableName: string, identifier: Object, options?: QueryOptions,
+    model?: typeof Model): Promise<Object>;
+
+  /**
+   * Returns selected rows
+   */
+  select(model: typeof Model, tableName: string, options?: QueryOptions): Promise<Array<Object>>;
+
+  /**
+   * Increments a row value
+   */
+  increment(instance: Model, tableName: string, values: Object, identifier: Object,
+    options?: QueryOptions): Promise<Object>;
+
+  /**
+   * Selects raw without parsing the string into an object
+   */
+  rawSelect(tableName: string, options: QueryOptions, attributeSelector: string | Array<string>,
+    model?: typeof Model): Promise<Array<string>>;
+
+  /**
+   * Postgres only. Creates a trigger on specified table to call the specified function with supplied
+   * parameters.
+   */
+  createTrigger(tableName: string, triggerName: string, timingType: string, fireOnArray: Array<any>,
+    functionName: string, functionParams: Array<any>, optionsArray: Array<string>,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Postgres only. Drops the specified trigger.
+   */
+  dropTrigger(tableName: string, triggerName: string, options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Postgres only. Renames a trigger
+   */
+  renameTrigger(tableName: string, oldTriggerName: string, newTriggerName: string,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Postgres only. Create a function
+   */
+  createFunction(functionName: string, params: Array<any>, returnType: string, language: string,
+    body: string, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Postgres only. Drops a function
+   */
+  dropFunction(functionName: string, params: Array<any>,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Postgres only. Rename a function
+   */
+  renameFunction(oldFunctionName: string, params: Array<any>, newFunctionName: string,
+    options?: QueryInterfaceOptions): Promise<void>;
+
+  /**
+   * Escape an identifier (e.g. a table or attribute name). If force is true, the identifier will be quoted
+   * even if the `quoteIdentifiers` option is false.
+   */
+  quoteIdentifier(identifier: string, force: boolean): string;
+
+  /**
+   * Escape a table name
+   */
+  quoteTable(identifier: string): string;
+
+  /**
+   * Split an identifier into .-separated tokens and quote each part. If force is true, the identifier will be
+   * quoted even if the `quoteIdentifiers` option is false.
+   */
+  quoteIdentifiers(identifiers: string, force: boolean): string;
+
+  /**
+   * Escape a value (e.g. a string, number or date)
+   */
+  escape(value?: string | number | Date): string;
+
+  /**
+   * Set option for autocommit of a transaction
+   */
+  setAutocommit(transaction: Transaction, value: boolean, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Set the isolation level of a transaction
+   */
+  setIsolationLevel(transaction: Transaction, value: string, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Begin a new transaction
+   */
+  startTransaction(transaction: Transaction, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Defer constraints
+   */
+  deferConstraints(transaction: Transaction, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Commit an already started transaction
+   */
+  commitTransaction(transaction: Transaction, options?: QueryOptions): Promise<void>;
+
+  /**
+   * Rollback ( revert ) a transaction that has'nt been commited
+   */
+  rollbackTransaction(transaction: Transaction, options?: QueryOptions): Promise<void>;
+
+}

--- a/4/lib/sequelize.d.ts
+++ b/4/lib/sequelize.d.ts
@@ -1,0 +1,1270 @@
+
+import {DataType} from './data-types';
+import {And, Or, Literal, Json, Where, Col, Cast, Fn} from './utils';
+import {Transaction, TransactionOptions} from './transaction';
+import {QueryInterface, QueryOptions} from './query-interface';
+import {DataTypes} from './data-types';
+import {Promise} from './promise';
+import {ModelManager} from './model-manager';
+import {
+  Model,
+  ModelAttributes,
+  ModelOptions,
+  DestroyOptions,
+  DropOptions,
+  CreateOptions,
+  InstanceDestroyOptions,
+  UpdateOptions,
+  BulkCreateOptions,
+  FindOptions
+} from './model';
+
+
+/**
+ * Sync Options
+ */
+export interface SyncOptions {
+
+  /**
+   * If force is true, each DAO will do DROP TABLE IF EXISTS ..., before it tries to create its own table
+   */
+  force?: boolean;
+
+  /**
+   * Match a regex against the database name before syncing, a safety check for cases where force: true is
+   * used in tests but not live code
+   */
+  match?: RegExp;
+
+  /**
+   * A function that logs sql queries, or false for no logging
+   */
+  logging?: Function | boolean;
+
+  /**
+   * The schema that the tables should be created in. This can be overriden for each table in sequelize.define
+   */
+  schema?: string;
+
+}
+
+export interface SetOptions { }
+
+/**
+ * Connection Pool options
+ */
+export interface PoolOptions {
+
+  /**
+   * Maximum connections of the pool
+   */
+  maxConnections?: number;
+
+  /**
+   * Minimum connections of the pool
+   */
+  minConnections?: number;
+
+  /**
+   * The maximum time, in milliseconds, that a connection can be idle before being released.
+   */
+  maxIdleTime?: number;
+
+  /**
+   * A function that validates a connection. Called with client. The default function checks that client is an
+   * object, and that its state is not disconnected.
+   */
+  validateConnection?: (client?: any) => boolean;
+
+}
+
+/**
+ * Interface for replication Options in the sequelize constructor
+ */
+export interface ReplicationOptions {
+
+  read?: {
+    host?: string,
+    port?: string | number,
+    username?: string,
+    password?: string,
+    database?: string
+  }
+
+  write?: {
+    host?: string,
+    port?: string | number,
+    username?: string,
+    password?: string,
+    database?: string
+  }
+
+}
+
+/**
+ * Options for the constructor of Sequelize main class
+ */
+export interface Options {
+
+  /**
+   * The dialect of the database you are connecting to. One of mysql, postgres, sqlite, mariadb and mssql.
+   *
+   * Defaults to 'mysql'
+   */
+  dialect?: 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql';
+
+  /**
+   * If specified, load the dialect library from this path. For example, if you want to use pg.js instead of
+   * pg when connecting to a pg database, you should specify 'pg.js' here
+   */
+  dialectModulePath?: string;
+
+  /**
+   * An object of additional options, which are passed directly to the connection library
+   */
+  dialectOptions?: Object;
+
+  /**
+   * Only used by sqlite.
+   *
+   * Defaults to ':memory:'
+   */
+  storage?: string;
+
+  /**
+   * The host of the relational database.
+   *
+   * Defaults to 'localhost'
+   */
+  host?: string;
+
+  /**
+   * The port of the relational database.
+   */
+  port?: number;
+
+  /**
+   * The protocol of the relational database.
+   *
+   * Defaults to 'tcp'
+   */
+  protocol?: string;
+
+  /**
+   * Default options for model definitions. See sequelize.define for options
+   */
+  define?: ModelOptions;
+
+  /**
+   * Default options for sequelize.query
+   */
+  query?: QueryOptions;
+
+  /**
+   * Default options for sequelize.set
+   */
+  set?: SetOptions;
+
+  /**
+   * Default options for sequelize.sync
+   */
+  sync?: SyncOptions;
+
+  /**
+   * The timezone used when converting a date from the database into a JavaScript date. The timezone is also
+   * used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP
+   * and other time related functions have in the right timezone. For best cross platform performance use the
+   * format
+   * +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles');
+   * this is useful to capture daylight savings time changes.
+   *
+   * Defaults to '+00:00'
+   */
+  timezone?: string;
+
+  /**
+   * A function that gets executed everytime Sequelize would log something.
+   *
+   * Defaults to console.log
+   */
+  logging?: boolean | Function;
+
+  /**
+   * A flag that defines if null values should be passed to SQL queries or not.
+   *
+   * Defaults to false
+   */
+  omitNull?: boolean;
+
+  /**
+   * A flag that defines if native library shall be used or not. Currently only has an effect for postgres
+   *
+   * Defaults to false
+   */
+  native?: boolean;
+
+  /**
+   * Use read / write replication. To enable replication, pass an object, with two properties, read and write.
+   * Write should be an object (a single server for handling writes), and read an array of object (several
+   * servers to handle reads). Each read/write server can have the following properties: `host`, `port`,
+   * `username`, `password`, `database`
+   *
+   * Defaults to false
+   */
+  replication?: ReplicationOptions;
+
+  /**
+   * Connection pool options
+   */
+  pool?: PoolOptions;
+
+  /**
+   * Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of
+   * them.
+   *
+   * Defaults to true
+   */
+  quoteIdentifiers?: boolean;
+
+  /**
+   * Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible
+   * options.
+   *
+   * Defaults to 'REPEATABLE_READ'
+   */
+  isolationLevel?: string;
+
+}
+
+export interface QueryOptionsTransactionRequired { }
+
+/**
+ * This is the main class, the entry point to sequelize. To use it, you just need to
+ * import sequelize:
+ *
+ * ```js
+ * var Sequelize = require('sequelize');
+ * ```
+ *
+ * In addition to sequelize, the connection library for the dialect you want to use
+ * should also be installed in your project. You don't need to import it however, as
+ * sequelize will take care of that.
+ */
+export class Sequelize {
+
+  /**
+   * A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
+   */
+  Sequelize: typeof Sequelize;
+
+  modelManager: ModelManager;
+
+  /**
+   * Creates a object representing a database function. This can be used in search queries, both in where and
+   * order parts, and as default values in column definitions. If you want to refer to columns in your
+   * function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and
+   * not a strings.
+   *
+   * Convert a user's username to upper case
+   * ```js
+   * instance.updateAttributes({
+   *   username: self.sequelize.fn('upper', self.sequelize.col('username'))
+   * })
+   * ```
+   * @param fn The function you want to call
+   * @param args All further arguments will be passed as arguments to the function
+   */
+  static fn(fn: string, ...args: any[]): Fn;
+
+  /**
+   * Creates a object representing a column in the DB. This is often useful in conjunction with
+   * `sequelize.fn`, since raw string arguments to fn will be escaped.
+   *
+   * @param col The name of the column
+   */
+  static col(col: string): Col;
+
+  /**
+   * Creates a object representing a call to the cast function.
+   *
+   * @param val The value to cast
+   * @param type The type to cast it to
+   */
+  static cast(val: any, type: string): Cast;
+
+  /**
+   * Creates a object representing a literal, i.e. something that will not be escaped.
+   *
+   * @param val
+   */
+  static literal(val: any): Literal;
+  static asIs(val: any): Literal;
+
+  /**
+   * An AND query
+   *
+   * @param args Each argument will be joined by AND
+   */
+  static and(...args: Array<string | Object>): And;
+
+  /**
+   * An OR query
+   *
+   * @param args Each argument will be joined by OR
+   */
+  static or(...args: Array<string | Object>): Or;
+
+  /**
+   * Creates an object representing nested where conditions for postgres's json data-type.
+   *
+   * @param conditionsOrPath A hash containing strings/numbers or other nested hash, a string using dot
+   *     notation or a string using postgres json syntax.
+   * @param value An optional value to compare against. Produces a string of the form "<json path> =
+   *     '<value>'".
+   */
+  static json(conditionsOrPath: string | Object, value?: string | number | boolean): Json;
+
+  /**
+   * A way of specifying attr = condition.
+   *
+   * The attr can either be an object taken from `Model.rawAttributes` (for example `Model.rawAttributes.id`
+   * or
+   * `Model.rawAttributes.name`). The attribute should be defined in your model definition. The attribute can
+   * also be an object from one of the sequelize utility functions (`sequelize.fn`, `sequelize.col` etc.)
+   *
+   * For string attributes, use the regular `{ where: { attr: something }}` syntax. If you don't want your
+   * string to be escaped, use `sequelize.literal`.
+   *
+   * @param attr The attribute, which can be either an attribute object from `Model.rawAttributes` or a
+   *     sequelize object, for example an instance of `sequelize.fn`. For simple string attributes, use the
+   *     POJO syntax
+   * @param comparator Comparator
+   * @param logic The condition. Can be both a simply type, or a further condition (`.or`, `.and`, `.literal`
+   *     etc.)
+   */
+  static where(attr: Object, comparator: string, logic: string | Object): Where;
+  static where(attr: Object, logic: string | Object): Where;
+  static condition(attr: Object, logic: string | Object): Where;
+
+  // -------------------- Static Hooks ---------------------------------------------------------------------
+
+  /**
+   * Add a hook to the model
+   *
+   * @param hookType
+   * @param name Provide a name for the hook function. It can be used to remove the hook later or to order
+   *     hooks based on some sort of priority system in the future.
+   * @param fn The hook function
+   *
+   * @alias hook
+   */
+  static addHook(hookType: string, name: string, fn: Function): typeof Sequelize;
+  static addHook(hookType: string, fn: Function): typeof Sequelize;
+  static hook(hookType: string, name: string, fn: Function): typeof Sequelize;
+  static hook(hookType: string, fn: Function): typeof Sequelize;
+
+  /**
+   * Remove hook from the model
+   *
+   * @param hookType
+   * @param name
+   */
+  static removeHook(hookType: string, name: string): typeof Sequelize;
+
+  /**
+   * Check whether the mode has any hooks of this type
+   *
+   * @param hookType
+   *
+   * @alias hasHooks
+   */
+  static hasHook(hookType: string): boolean;
+  static hasHooks(hookType: string): boolean;
+
+  /**
+   * A hook that is run before validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static beforeValidate(name: string, fn: (instance: Model, options: Object) => void): void;
+  static beforeValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run after validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static afterValidate(name: string,
+    fn: (instance: Model, options: Object) => void): void;
+  static afterValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run before creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  static beforeCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  static beforeCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  static afterCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  static afterCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias beforeDelete
+   */
+  static beforeDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static beforeDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias afterDelete
+   */
+  static afterDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  static afterDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run before updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static beforeUpdate(name: string,
+    fn: (instance: Model, options: UpdateOptions) => void): void;
+  static beforeUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  static afterUpdate(name: string, fn: (instance: Model, options: UpdateOptions) => void): void;
+  static afterUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   */
+  static beforeBulkCreate(name: string, fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  static beforeBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   * @name afterBulkCreate
+   */
+  static afterBulkCreate(name: string, fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  static afterBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias beforeBulkDelete
+   */
+  static beforeBulkDestroy(name: string, fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDestroy(fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDelete(name: string, fn: (options: BulkCreateOptions) => void): void;
+  static beforeBulkDelete(fn: (options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias afterBulkDelete
+   */
+  static afterBulkDestroy(name: string, fn: (options: DestroyOptions) => void): void;
+  static afterBulkDestroy(fn: (options: DestroyOptions) => void): void;
+  static afterBulkDelete(name: string, fn: (options: DestroyOptions) => void): void;
+  static afterBulkDelete(fn: (options: DestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  static beforeBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static afterBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  static afterBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFind(name: string, fn: (options: FindOptions) => void): void;
+  static beforeFind(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFindAfterExpandIncludeAll(name: string,
+    fn: (options: FindOptions) => void): void;
+  static beforeFindAfterExpandIncludeAll(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after all option parsing is complete
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  static beforeFindAfterOptions(name: string, fn: (options: FindOptions) => void): void;
+  static beforeFindAfterOptions(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run after a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with instance(s), options
+   */
+  static afterFind(name: string, fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+  static afterFind(fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+
+  /**
+   * A hook that is run before a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with attributes, options
+   */
+  static beforeDefine(name: string, fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+  static beforeDefine(fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+
+  /**
+   * A hook that is run after a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with factory
+   */
+  static afterDefine(name: string, fn: (model: typeof Model) => void): void;
+  static afterDefine(fn: (model: typeof Model) => void): void;
+
+  /**
+   * A hook that is run before Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with config, options
+   */
+  static beforeInit(name: string, fn: (config: Object, options: Object) => void): void;
+  static beforeInit(fn: (config: Object, options: Object) => void): void;
+
+  /**
+   * A hook that is run after Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with sequelize
+   */
+  static afterInit(name: string, fn: (sequelize: Sequelize) => void): void;
+  static afterInit(fn: (sequelize: Sequelize) => void): void;
+
+  /**
+   * A hook that is run before sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name beforeBulkSync
+   */
+  static beforeBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  static beforeBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name afterBulkSync
+   */
+  static afterBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  static afterBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run before Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name beforeSync
+   */
+  static beforeSync(name: string, fn: (options: SyncOptions) => any): void;
+  static beforeSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name afterSync
+   */
+  static afterSync(name: string, fn: (options: SyncOptions) => any): void;
+  static afterSync(fn: (options: SyncOptions) => any): void;
+
+  // --------------------------- instance hooks -----------------------------------------------------------
+
+  /**
+   * Add a hook to the model
+   *
+   * @param hookType
+   * @param name Provide a name for the hook function. It can be used to remove the hook later or to order
+   *     hooks based on some sort of priority system in the future.
+   * @param fn The hook function
+   *
+   * @alias hook
+   */
+  addHook(hookType: string, name: string, fn: Function): typeof Sequelize;
+  addHook(hookType: string, fn: Function): typeof Sequelize;
+  hook(hookType: string, name: string, fn: Function): typeof Sequelize;
+  hook(hookType: string, fn: Function): typeof Sequelize;
+
+  /**
+   * Remove hook from the model
+   *
+   * @param hookType
+   * @param name
+   */
+  removeHook(hookType: string, name: string): typeof Sequelize;
+
+  /**
+   * Check whether the mode has any hooks of this type
+   *
+   * @param hookType
+   *
+   * @alias hasHooks
+   */
+  hasHook(hookType: string): boolean;
+  hasHooks(hookType: string): boolean;
+
+  /**
+   * A hook that is run before validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  beforeValidate(name: string, fn: (instance: Model, options: Object) => void): void;
+  beforeValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run after validation
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  afterValidate(name: string,
+    fn: (instance: Model, options: Object) => void): void;
+  afterValidate(fn: (instance: Model, options: Object) => void): void;
+
+  /**
+   * A hook that is run before creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  beforeCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  beforeCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with attributes, options
+   */
+  afterCreate(name: string, fn: (attributes: Model, options: CreateOptions) => void): void;
+  afterCreate(fn: (attributes: Model, options: CreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias beforeDelete
+   */
+  beforeDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  beforeDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  beforeDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  beforeDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   * @alias afterDelete
+   */
+  afterDestroy(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  afterDestroy(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  afterDelete(name: string, fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+  afterDelete(fn: (instance: Model, options: InstanceDestroyOptions) => void): void;
+
+  /**
+   * A hook that is run before updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  beforeUpdate(name: string,
+    fn: (instance: Model, options: UpdateOptions) => void): void;
+  beforeUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating a single instance
+   *
+   * @param name
+   * @param fn A callback function that is called with instance, options
+   */
+  afterUpdate(name: string, fn: (instance: Model, options: UpdateOptions) => void): void;
+  afterUpdate(fn: (instance: Model, options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   */
+  beforeBulkCreate(name: string, fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  beforeBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after creating instances in bulk
+   *
+   * @param name
+   * @param fn A callback function that is called with instances, options
+   * @name afterBulkCreate
+   */
+  afterBulkCreate(name: string, fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+  afterBulkCreate(fn: (instances: Model[], options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run before destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias beforeBulkDelete
+   */
+  beforeBulkDestroy(name: string, fn: (options: BulkCreateOptions) => void): void;
+  beforeBulkDestroy(fn: (options: BulkCreateOptions) => void): void;
+  beforeBulkDelete(name: string, fn: (options: BulkCreateOptions) => void): void;
+  beforeBulkDelete(fn: (options: BulkCreateOptions) => void): void;
+
+  /**
+   * A hook that is run after destroying instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   *
+   * @alias afterBulkDelete
+   */
+  afterBulkDestroy(name: string, fn: (options: DestroyOptions) => void): void;
+  afterBulkDestroy(fn: (options: DestroyOptions) => void): void;
+  afterBulkDelete(name: string, fn: (options: DestroyOptions) => void): void;
+  afterBulkDelete(fn: (options: DestroyOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  beforeBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  beforeBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run after updating instances in bulk
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  afterBulkUpdate(name: string, fn: (options: UpdateOptions) => void): void;
+  afterBulkUpdate(fn: (options: UpdateOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  beforeFind(name: string, fn: (options: FindOptions) => void): void;
+  beforeFind(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  beforeFindAfterExpandIncludeAll(name: string,
+    fn: (options: FindOptions) => void): void;
+  beforeFindAfterExpandIncludeAll(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a find (select) query, after all option parsing is complete
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  beforeFindAfterOptions(name: string, fn: (options: FindOptions) => void): void;
+  beforeFindAfterOptions(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run after a find (select) query
+   *
+   * @param name
+   * @param fn   A callback function that is called with instance(s), options
+   */
+  afterFind(name: string, fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+  afterFind(fn: (instancesOrInstance: Model[] | Model, options: FindOptions,
+    fn?: Function) => void): void;
+
+  /**
+   * A hook that is run before a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with attributes, options
+   */
+  beforeDefine(name: string, fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+  beforeDefine(fn: (attributes: ModelAttributes, options: ModelOptions) => void): void;
+
+  /**
+   * A hook that is run after a define call
+   *
+   * @param name
+   * @param fn   A callback function that is called with factory
+   */
+  afterDefine(name: string, fn: (model: typeof Model) => void): void;
+  afterDefine(fn: (model: typeof Model) => void): void;
+
+  /**
+   * A hook that is run before Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with config, options
+   */
+  beforeInit(name: string, fn: (config: Object, options: Object) => void): void;
+  beforeInit(fn: (config: Object, options: Object) => void): void;
+
+  /**
+   * A hook that is run after Sequelize() call
+   *
+   * @param name
+   * @param fn   A callback function that is called with sequelize
+   */
+  afterInit(name: string, fn: (sequelize: Sequelize) => void): void;
+  afterInit(fn: (sequelize: Sequelize) => void): void;
+
+  /**
+   * A hook that is run before sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name beforeBulkSync
+   */
+  beforeBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  beforeBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name afterBulkSync
+   */
+  afterBulkSync(name: string, fn: (options: SyncOptions) => any): void;
+  afterBulkSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run before Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name beforeSync
+   */
+  beforeSync(name: string, fn: (options: SyncOptions) => any): void;
+  beforeSync(fn: (options: SyncOptions) => any): void;
+
+  /**
+   * A hook that is run after Model.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to Model.sync
+   * @name afterSync
+   */
+  afterSync(name: string, fn: (options: SyncOptions) => any): void;
+  afterSync(fn: (options: SyncOptions) => any): void;
+
+
+  /**
+   * Instantiate sequelize with name of database, username and password
+   *
+   * #### Example usage
+   *
+   * ```javascript
+   * // without password and options
+   * var sequelize = new Sequelize('database', 'username')
+   *
+   * // without options
+   * var sequelize = new Sequelize('database', 'username', 'password')
+   *
+   * // without password / with blank password
+   * var sequelize = new Sequelize('database', 'username', null, {})
+   *
+   * // with password and options
+   * var sequelize = new Sequelize('my_database', 'john', 'doe', {})
+   *
+   * // with uri (see below)
+   * var sequelize = new Sequelize('mysql://localhost:3306/database', {})
+   * ```
+   *
+   * @param database The name of the database
+   * @param username The username which is used to authenticate against the
+   *     database.
+   * @param password The password which is used to authenticate against the
+   *     database.
+   * @param options An object with options.
+   */
+  constructor(database: string, username: string, password: string, options?: Options);
+  constructor(database: string, username: string, options?: Options);
+
+  /**
+   * Instantiate sequelize with an URI
+   * @name Sequelize
+   * @constructor
+   *
+   * @param uri A full database URI
+   * @param options See above for possible options
+   */
+  constructor(uri: string, options?: Options);
+
+  /**
+   * Returns the specified dialect.
+   */
+  getDialect(): string;
+
+  /**
+   * Returns an instance of QueryInterface.
+   */
+  getQueryInterface(): QueryInterface;
+
+  /**
+   * Define a new model, representing a table in the DB.
+   *
+   * The table columns are define by the hash that is given as the second argument. Each attribute of the
+   * hash
+   * represents a column. A short table definition might look like this:
+   *
+   * ```js
+   * sequelize.define('modelName', {
+   *     columnA: {
+   *         type: Sequelize.BOOLEAN,
+   *         validate: {
+   *           is: ["[a-z]",'i'],        // will only allow letters
+   *           max: 23,                  // only allow values <= 23
+   *           isIn: {
+   *             args: [['en', 'zh']],
+   *             msg: "Must be English or Chinese"
+   *           }
+   *         },
+   *         field: 'column_a'
+   *         // Other attributes here
+   *     },
+   *     columnB: Sequelize.STRING,
+   *     columnC: 'MY VERY OWN COLUMN TYPE'
+   * })
+   *
+   * sequelize.models.modelName // The model will now be available in models under the name given to define
+   * ```
+   *
+   * As shown above, column definitions can be either strings, a reference to one of the datatypes that are
+   * predefined on the Sequelize constructor, or an object that allows you to specify both the type of the
+   * column, and other attributes such as default values, foreign key constraints and custom setters and
+   * getters.
+   *
+   * For a list of possible data types, see
+   * http://docs.sequelizejs.com/en/latest/docs/models-definition/#data-types
+   *
+   * For more about getters and setters, see
+   * http://docs.sequelizejs.com/en/latest/docs/models-definition/#getters-setters
+   *
+   * For more about instance and class methods, see
+   * http://docs.sequelizejs.com/en/latest/docs/models-definition/#expansion-of-models
+   *
+   * For more about validation, see
+   * http://docs.sequelizejs.com/en/latest/docs/models-definition/#validations
+   *
+   * @param modelName  The name of the model. The model will be stored in `sequelize.models` under this name
+   * @param attributes An object, where each attribute is a column of the table. Each column can be either a
+   *                   DataType, a string or a type-description object, with the properties described below:
+   * @param options    These options are merged with the default define options provided to the Sequelize
+   *                   constructor
+   */
+  define<TModel>(modelName: string, attributes: ModelAttributes, options?: ModelOptions): TModel;
+
+  /**
+   * Fetch a Model which is already defined
+   *
+   * @param modelName The name of a model defined with Sequelize.define
+   */
+  model(modelName: string): typeof Model;
+
+  /**
+   * Checks whether a model with the given name is defined
+   *
+   * @param modelName The name of a model defined with Sequelize.define
+   */
+  isDefined(modelName: string): boolean;
+
+  /**
+   * Imports a model defined in another file
+   *
+   * Imported models are cached, so multiple calls to import with the same path will not load the file
+   * multiple times
+   *
+   * See https://github.com/sequelize/sequelize/blob/master/examples/using-multiple-model-files/Task.js for a
+   * short example of how to define your models in separate files so that they can be imported by
+   * sequelize.import
+   *
+   * @param path The path to the file that holds the model you want to import. If the part is relative, it
+   *     will be resolved relatively to the calling file
+   *
+   * @param defineFunction An optional function that provides model definitions. Useful if you do not
+   *     want to use the module root as the define function
+   */
+  import<T extends typeof Model>(
+    path: string,
+    defineFunction?: (sequelize: Sequelize, dataTypes: DataTypes) => T
+  ): T;
+
+  /**
+   * Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
+   *
+   * By default, the function will return two arguments: an array of results, and a metadata object,
+   * containing number of affected rows etc. Use `.spread` to access the results.
+   *
+   * If you are running a type of query where you don't need the metadata, for example a `SELECT` query, you
+   * can pass in a query type to make sequelize format the results:
+   *
+   * ```js
+   * sequelize.query('SELECT...').spread(function (results, metadata) {
+   *   // Raw query - use spread
+   * });
+   *
+   * sequelize.query('SELECT...', { type: sequelize.QueryTypes.SELECT }).then(function (results) {
+   *   // SELECT query - use then
+   * })
+   * ```
+   *
+   * @param sql
+   * @param options Query options
+   */
+  query(sql: string | { query: string, values: Array<any> }, options?: QueryOptions): Promise<any>;
+
+  /**
+   * Execute a query which would set an environment or user variable. The variables are set per connection,
+   * so this function needs a transaction.
+   *
+   * Only works for MySQL.
+   *
+   * @param variables Object with multiple variables.
+   * @param options Query options.
+   */
+  set(variables: Object, options: QueryOptionsTransactionRequired): Promise<any>;
+
+  /**
+   * Escape value.
+   *
+   * @param value Value that needs to be escaped
+   */
+  escape(value: string | number | Date): string;
+
+  /**
+   * Create a new database schema.
+   *
+   * Note,that this is a schema in the
+   * [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
+   * not a database table. In mysql and sqlite, this command will do nothing.
+   *
+   * @param schema Name of the schema
+   * @param options Options supplied
+   * @param options.logging A function that logs sql queries, or false for no logging
+   */
+  createSchema(schema: string, options: { logging?: boolean | Function }): Promise<any>;
+
+  /**
+   * Show all defined schemas
+   *
+   * Note,that this is a schema in the
+   * [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
+   * not a database table. In mysql and sqlite, this will show all tables.
+   *
+   * @param options Options supplied
+   * @param options.logging A function that logs sql queries, or false for no logging
+   */
+  showAllSchemas(options: { logging?: boolean | Function }): Promise<any>;
+
+  /**
+   * Drop a single schema
+   *
+   * Note,that this is a schema in the
+   * [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
+   * not a database table. In mysql and sqlite, this drop a table matching the schema name
+   *
+   * @param schema Name of the schema
+   * @param options Options supplied
+   * @param options.logging A function that logs sql queries, or false for no logging
+   */
+  dropSchema(schema: string, options: { logging?: boolean | Function }): Promise<any>;
+
+  /**
+   * Drop all schemas
+   *
+   * Note,that this is a schema in the
+   * [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
+   * not a database table. In mysql and sqlite, this is the equivalent of drop all tables.
+   *
+   * @param options Options supplied
+   * @param options.logging A function that logs sql queries, or false for no logging
+   */
+  dropAllSchemas(options: { logging?: boolean | Function }): Promise<any>;
+
+  /**
+   * Sync all defined models to the DB.
+   *
+   * @param options Sync Options
+   */
+  sync(options?: SyncOptions): Promise<any>;
+
+  /**
+   * Truncate all tables defined through the sequelize models. This is done
+   * by calling Model.truncate() on each model.
+   *
+   * @param {object} [options] The options passed to Model.destroy in addition to truncate
+   * @param {Boolean|function} [options.transaction]
+   * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
+   */
+  truncate(options?: DestroyOptions): Promise<any>;
+
+  /**
+   * Drop all tables defined through this sequelize instance. This is done by calling Model.drop on each model
+   *
+   * @param options The options passed to each call to Model.drop
+   */
+  drop(options?: DropOptions): Promise<any>;
+
+  /**
+   * Test the connection by trying to authenticate
+   *
+   * @param options Query Options for authentication
+   */
+  authenticate(options?: QueryOptions): Promise<void>;
+  validate(options?: QueryOptions): Promise<void>;
+
+  /**
+   * Start a transaction. When using transactions, you should pass the transaction in the options argument
+   * in order for the query to happen under that transaction
+   *
+   * ```js
+   * sequelize.transaction().then(function (t) {
+   *   return User.find(..., { transaction: t}).then(function (user) {
+   *     return user.updateAttributes(..., { transaction: t});
+   *   })
+   *   .then(t.commit.bind(t))
+   *   .catch(t.rollback.bind(t));
+   * })
+   * ```
+   *
+   * A syntax for automatically committing or rolling back based on the promise chain resolution is also
+   * supported:
+   *
+   * ```js
+   * sequelize.transaction(function (t) { // Note that we use a callback rather than a promise.then()
+   *   return User.find(..., { transaction: t}).then(function (user) {
+   *     return user.updateAttributes(..., { transaction: t});
+   *   });
+   * }).then(function () {
+   *   // Commited
+   * }).catch(function (err) {
+   *   // Rolled back
+   *   console.error(err);
+   * });
+   * ```
+   *
+   * If you have [CLS](https://github.com/othiym23/node-continuation-local-storage) enabled, the transaction
+   * will automatically be passed to any query that runs witin the callback. To enable CLS, add it do your
+   * project, create a namespace and set it on the sequelize constructor:
+   *
+   * ```js
+   * var cls = require('continuation-local-storage'),
+   *     ns = cls.createNamespace('....');
+   * var Sequelize = require('sequelize');
+   * Sequelize.cls = ns;
+   * ```
+   * Note, that CLS is enabled for all sequelize instances, and all instances will share the same namespace
+   *
+   * @param options Transaction Options
+   * @param autoCallback Callback for the transaction
+   */
+  transaction(options: TransactionOptions, autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
+  transaction(autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
+  transaction(options?: TransactionOptions): Promise<Transaction>;
+
+  /**
+   * Close all connections used by this sequelize instance, and free all references so the instance can be
+   * garbage collected.
+   *
+   * Normally this is done on process exit, so you only need to call this method if you are creating multiple
+   * instances, and want to garbage collect some of them.
+   */
+  close(): void;
+
+  /**
+   * Returns the database version
+   */
+  databaseVersion(): Promise<string>;
+
+}
+
+export * from './model';
+export * from './transaction';
+export * from './model';
+export * from './data-types';
+export * from './associations/index';
+export * from './errors';
+export {BaseError as Error} from './errors';
+export {useInflection} from './utils';
+export {Deferrable} from './deferrable';
+export {Promise} from './promise';
+export {Validator} from './utils/validator-extras';
+
+export default Sequelize;

--- a/4/lib/sql-string.d.ts
+++ b/4/lib/sql-string.d.ts
@@ -1,0 +1,4 @@
+export function escapeId(val: string, forbidQualified?: boolean): string;
+export function escape(val: any, timeZone?: string, dialect?: string, format?: string): string;
+export function format(sql: string, values: any[], timeZone?: string, dialect?: string): string;
+export function formatNamedParameters(sql: string, values: any[], timeZone?: string, dialect?: string): string;

--- a/4/lib/transaction.d.ts
+++ b/4/lib/transaction.d.ts
@@ -1,0 +1,136 @@
+
+import {Promise} from './promise';
+import {Sequelize} from './sequelize';
+
+/**
+ * The transaction object is used to identify a running transaction. It is created by calling
+ * `Sequelize.transaction()`.
+ *
+ * To run a query under a transaction, you should pass the transaction in the options object.
+ */
+export class Transaction {
+
+  constructor(sequelize: Sequelize, options: TransactionOptions);
+
+  /**
+   * Commit the transaction
+   */
+  commit(): Promise<void>;
+
+  /**
+   * Rollback (abort) the transaction
+   */
+  rollback(): Promise<void>;
+
+}
+
+export type TransactionType = 'DEFERRED' | 'IMMEDIATE' | 'EXCLUSIVE';
+export const TYPES: {
+  DEFERRED: 'DEFERRED',
+  IMMEDIATE: 'IMMEDIATE',
+  EXCLUSIVE: 'EXCLUSIVE'
+}
+
+/**
+ * Isolations levels can be set per-transaction by passing `options.isolationLevel` to `sequelize.transaction`.
+ * Default to `REPEATABLE_READ` but you can override the default isolation level by passing `options.isolationLevel` in `new Sequelize`.
+ *
+ * The possible isolations levels to use when starting a transaction:
+ *
+ * ```js
+ * {
+ *   READ_UNCOMMITTED: "READ UNCOMMITTED",
+ *   READ_COMMITTED: "READ COMMITTED",
+ *   REPEATABLE_READ: "REPEATABLE READ",
+ *   SERIALIZABLE: "SERIALIZABLE"
+ * }
+ * ```
+ *
+ * Pass in the desired level as the first argument:
+ *
+ * ```js
+ * return sequelize.transaction({isolationLevel: Sequelize.Transaction.SERIALIZABLE}, transaction => {
+ *
+ *  // your transactions
+ *
+ * }).then(result => {
+ *   // transaction has been committed. Do something after the commit if required.
+ * }).catch(err => {
+ *   // do something with the err.
+ * });
+ * ```
+ */
+export const ISOLATION_LEVELS: {
+  READ_UNCOMMITTED: 'READ UNCOMMITTED',
+  READ_COMMITTED: 'READ COMMITTED',
+  REPEATABLE_READ: 'REPEATABLE READ',
+  SERIALIZABLE: 'SERIALIZABLE'
+};
+
+/**
+ * Possible options for row locking. Used in conjunction with `find` calls:
+ *
+ * ```js
+ * t1 // is a transaction
+ * t1.LOCK.UPDATE,
+ * t1.LOCK.SHARE,
+ * t1.LOCK.KEY_SHARE, // Postgres 9.3+ only
+ * t1.LOCK.NO_KEY_UPDATE // Postgres 9.3+ only
+ * ```
+ *
+ * Usage:
+ * ```js
+ * t1 // is a transaction
+ * Model.findAll({
+ *   where: ...,
+ *   transaction: t1,
+ *   lock: t1.LOCK...
+ * });
+ * ```
+ *
+ * Postgres also supports specific locks while eager loading by using OF:
+ * ```js
+ * UserModel.findAll({
+ *   where: ...,
+ *   include: [TaskModel, ...],
+ *   transaction: t1,
+ *   lock: {
+ *     level: t1.LOCK...,
+ *     of: UserModel
+ *   }
+ * });
+ * ```
+ * UserModel will be locked but TaskModel won't!
+ *
+ * @property LOCK
+ */
+export const LOCK: {
+  UPDATE: 'UPDATE',
+  SHARE: 'SHARE',
+  KEY_SHARE: 'KEY SHARE',
+  NO_KEY_UPDATE: 'NO KEY UPDATE'
+}
+export type TransactionLock = 'UDPATE' | 'SHARE' | 'KEY SHARE' | 'NO KEY UPDATE';
+
+/**
+ * Options provided when the transaction is created
+ */
+export interface TransactionOptions {
+
+  autocommit?: boolean;
+
+  /**
+   *  See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
+   */
+  isolationLevel?: string;
+
+  /**
+   * A function that gets executed while running the query to log the sql.
+   */
+  logging?: Function;
+
+  type?: TransactionType;
+  deferrable?: string;
+}
+
+export default Transaction;

--- a/4/lib/utils.d.ts
+++ b/4/lib/utils.d.ts
@@ -1,0 +1,125 @@
+
+import parameterValidator = require('./utils/parameter-validator');
+
+export type Primitive = 'string'|'number'|'boolean';
+
+export function useInflection(inflection: any): void;
+
+export function camelizeIf(string: string, condition?: boolean): string;
+export function underscoredIf(string: string, condition?: boolean): string;
+export function isPrimitive(val: any): val is Primitive;
+
+/** Same concept as _.merge, but don't overwrite properties that have already been assigned */
+export function mergeDefaults(a: any, b: any): any;
+export function lowercaseFirst(s: string): string;
+export function uppercaseFirst(s: string): string;
+export function spliceStr(str: string, index: number, count: number, add: string): string;
+export function camelize(str: string): string;
+export function format(arr: any[], dialect: string): string;
+export function formatNamedParameters(sql: string, parameters: any, dialect: string): string;
+export function cloneDeep<T>(obj: T, fn?: Function): T;
+
+/** Expand and normalize finder options */
+export function mapFinderOptions(options: any, Model: any): any;
+
+/* Used to map field names in attributes and where conditions */
+export function mapOptionFieldNames(options: any, Model: any): any;
+
+export function mapWhereFieldNames(attributes: any, Model: any): any;
+/** Used to map field names in values */
+export function mapValueFieldNames(dataValues: any, fields: any, Model: any): any;
+
+export function isColString(value: string): boolean;
+export function argsArePrimaryKeys(args: any, primaryKeys: any): boolean;
+export function canTreatArrayAsAnd(arr: any[]): boolean;
+export function combineTableNames(tableName1: string, tableName2: string): string;
+
+export function singularize(s: string): string;
+export function pluralize(s: string): string;
+
+export function removeCommentsFromFunctionString(s: string): string;
+export function toDefaultValue(value: any): any;
+
+
+/**
+ * Determine if the default value provided exists and can be described
+ * in a db schema using the DEFAULT directive.
+ *
+ * @param  {*} value Any default value.
+ * @return {boolean} yes / no.
+ */
+export function defaultValueSchemable(value: any): boolean;
+
+export function defaultValueSchemable(hash: any, omitNull: any, options: any): any;
+export function inherit(SubClass: any, SuperClass: any): any;
+export function stack(): string;
+export function sliceArgs(args: any, begin: any): any[];
+export function now(dialect: string): Date;
+export function tick(func: Function): void;
+
+// Note: Use the `quoteIdentifier()` and `escape()` methods on the
+// `QueryInterface` instead for more portable code.
+export const TICK_CHAR: string;
+export function addTicks(s: string, tickChar?: string): string;
+export function removeTicks(s: string, tickChar?: string): string;
+
+/*
+ * Utility functions for representing SQL functions, and columns that should be escaped.
+ * Please do not use these functions directly, use Sequelize.fn and Sequelize.col instead.
+ */
+export class Fn {
+  private _isSequelizeMethod: boolean;
+  constructor(fn: any, args: any);
+  clone(): this;
+}
+
+export class Col {
+  col: string;
+  private _isSequelizeMethod: boolean;
+  constructor(col: string);
+}
+
+export class Cast {
+  val: any;
+  type: string;
+  private _isSequelizeMethod: boolean;
+  constructor(val: any, type?: string);
+}
+
+export class Literal {
+  val: any;
+  private _isSequelizeMethod: boolean;
+  constructor(val: any);
+}
+
+export class Json {
+  conditions: Object;
+  path: string;
+  value: string | number | boolean;
+  private _isSequelizeMethod: boolean;
+  constructor(conditionsOrPath: string | Object, value?: string | number | boolean);
+}
+
+export class Where {
+  attribute: Object;
+  comparator: string;
+  logic: string | Object;
+  private _isSequelizeMethod: boolean;
+  constructor(attr: Object, comparator: string, logic: string | Object);
+  constructor(attr: Object, logic: string | Object);
+}
+
+export class And {
+  args: any[];
+  constructor(...args: Array<string | Object>);
+}
+
+export class Or {
+  args: any[];
+  constructor(...args: Array<string | Object>);
+}
+
+export const validateParameter: typeof parameterValidator;
+export function formatReferences(obj: any): any;
+
+export {Promise as Promise} from './promise';

--- a/4/lib/utils/parameter-validator.d.ts
+++ b/4/lib/utils/parameter-validator.d.ts
@@ -1,0 +1,8 @@
+declare function check(value: any, expectation: any, options?: {
+  deprecated?: boolean;
+  index?: any;
+  method?: any;
+  optional?: boolean;
+}): boolean;
+
+export = check;

--- a/4/lib/utils/validator-extras.d.ts
+++ b/4/lib/utils/validator-extras.d.ts
@@ -1,0 +1,25 @@
+import {ValidatorStatic} from 'validator';
+
+export interface Extensions {
+  notEmpty(str: string): boolean;
+  len(str: string, min: number, max: number): boolean;
+  isUrl(str: string): boolean;
+  isIPv6(str: string): boolean;
+  isIPv4(str: string): boolean;
+  notIn(str: string, values: Array<string>): boolean;
+  regex(str: string, pattern: string, modifiers: string): boolean;
+  notRegex(str: string, pattern: string, modifiers: string): boolean;
+  isDecimal(str: string): boolean;
+  min(str: string, val: number): boolean;
+  max(str: string, val: number): boolean;
+  not(str: string, pattern: string, modifiers: string): boolean;
+  contains(str: string, elem: Array<string>): boolean;
+  notContains(str: string, elem: Array<string>): boolean;
+  is(str: string, pattern: string, modifiers: string): boolean;
+}
+export const extensions: Extensions;
+
+export interface Validator extends ValidatorStatic, Extensions {
+  contains(str: string, elem: string[]): boolean;
+}
+export const validator: Validator;

--- a/4/test/connection.ts
+++ b/4/test/connection.ts
@@ -1,0 +1,8 @@
+
+import {Sequelize, SyncOptions} from 'sequelize';
+
+export const sequelize = new Sequelize('uri');
+
+sequelize.afterBulkSync((options: SyncOptions) => {
+  console.log('synced');
+});

--- a/4/test/define.ts
+++ b/4/test/define.ts
@@ -1,0 +1,34 @@
+
+import {STRING, Model} from 'sequelize';
+import {sequelize} from './connection';
+
+// I really wouldn't recommend this, but if you want you can still use define() and interfaces
+
+type UserInstance = {
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+} & Model;
+
+type User = {
+  new (): UserInstance;
+  customStaticMethod(): any;
+} & typeof Model;
+
+const User: User = sequelize.define<User>('User', {firstName: STRING}, {tableName: 'users'});
+
+async function test() {
+
+  User.customStaticMethod();
+
+  const user: UserInstance = new User();
+
+  const user2: UserInstance = await User.find() as UserInstance;
+
+  user2.firstName = 'John';
+
+  await user2.save();
+}

--- a/4/test/errors.ts
+++ b/4/test/errors.ts
@@ -1,0 +1,15 @@
+
+// Error === BaseError
+import {Error, BaseError, UniqueConstraintError} from 'sequelize';
+import {User} from './models/User';
+
+async function test() {
+  try {
+    await User.create({username: 'john_doe'});
+  } catch (e) {
+    if (e instanceof UniqueConstraintError) {
+      console.error((<UniqueConstraintError>e).sql);
+    }
+  }
+}
+

--- a/4/test/models/User.ts
+++ b/4/test/models/User.ts
@@ -1,0 +1,43 @@
+
+import {
+  Model,
+  FindOptions,
+  STRING,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  BelongsToCreateAssociationMixin
+} from 'sequelize';
+import {sequelize} from '../connection';
+
+export class User extends Model {
+
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  // mixins for association (optional)
+  groupId: number;
+  group: UserGroup;
+  getGroup: BelongsToGetAssociationMixin<UserGroup>;
+  setGroup: BelongsToSetAssociationMixin<UserGroup, number>;
+  createGroup: BelongsToCreateAssociationMixin<UserGroup>;
+}
+
+User.init({
+  username: STRING,
+  firstName: STRING,
+  lastName: STRING
+}, {}, sequelize.modelManager);
+
+// Hooks
+User.afterFind((users: User[], options: FindOptions) => {
+  console.log('found');
+});
+
+// associate
+// it is important to import _after_ the model above is already exported so the circular reference works.
+import {UserGroup} from './UserGroup';
+export const Group = User.belongsTo(UserGroup, {as: 'group', foreignKey: 'groupId'});

--- a/4/test/models/UserGroup.ts
+++ b/4/test/models/UserGroup.ts
@@ -1,0 +1,40 @@
+import {sequelize} from '../connection';
+import {
+  Model,
+  STRING,
+  HasManyAddAssociationMixin,
+  HasManyCountAssociationsMixin,
+  HasManyGetAssociationsMixin,
+  HasManySetAssociationsMixin,
+  HasManyHasAssociationMixin,
+  HasManyAddAssociationsMixin,
+  HasManyCreateAssociationMixin,
+  HasManyRemoveAssociationMixin,
+  HasManyRemoveAssociationsMixin
+} from 'sequelize';
+
+export class UserGroup extends Model {
+
+  id: number;
+  name: string;
+
+  // mixins for association (optional)
+  users: User[];
+  getUsers: HasManyGetAssociationsMixin<User>;
+  setUsers: HasManySetAssociationsMixin<User, number>;
+  addUser: HasManyAddAssociationMixin<User, number>;
+  addUsers: HasManyAddAssociationsMixin<User, number>;
+  countUsers: HasManyCountAssociationsMixin;
+  hasUser: HasManyHasAssociationMixin<User, number>;
+  removeUser: HasManyRemoveAssociationMixin<User, number>;
+  removeUsers: HasManyRemoveAssociationsMixin<User, number>;
+}
+
+// attach all the metadata to the model
+// instead of this, you could also use decorators
+UserGroup.init({name: STRING}, {}, sequelize.modelManager);
+
+// associate
+// it is important to import _after_ the model above is already exported so the circular reference works.
+import {User} from './User';
+export const Users = UserGroup.hasMany(User, {as: 'users', foreignKey: 'groupId'});

--- a/4/test/promise.ts
+++ b/4/test/promise.ts
@@ -1,0 +1,8 @@
+import {Promise} from 'sequelize';
+
+let promise: Promise<number>;
+promise
+  .then((arg: number) => ({}))
+  .then((a: {}) => void 0);
+
+promise = new Promise<number>(() => {});

--- a/4/test/query-interface.ts
+++ b/4/test/query-interface.ts
@@ -1,0 +1,125 @@
+import {DataTypes} from 'sequelize';
+import {QueryInterface} from 'sequelize/lib/query-interface';
+
+let queryInterface: QueryInterface;
+
+queryInterface.createTable(
+  'nameOfTheNewTable',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    createdAt: {
+      type: DataTypes.DATE
+    },
+    updatedAt: {
+      type: DataTypes.DATE
+    },
+    attr1: DataTypes.STRING,
+    attr2: DataTypes.INTEGER,
+    attr3: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false
+    },
+    //foreign key usage
+    attr4: {
+        type: DataTypes.INTEGER,
+        references: {
+            model: 'another_table_name',
+            key: 'id'
+        },
+        onUpdate: 'cascade',
+        onDelete: 'cascade'
+    }
+  },
+  {
+    engine: 'MYISAM', // default: 'InnoDB'
+    charset: 'latin1' // default: null
+  }
+);
+
+queryInterface.dropTable('nameOfTheExistingTable');
+
+queryInterface.dropAllTables();
+
+queryInterface.renameTable('Person', 'User');
+
+queryInterface.showAllTables().then(function(tableNames) {})
+
+queryInterface.describeTable('Person').then(function(attributes) {
+  /*
+    attributes will be something like:
+
+    {
+      name: {
+        type:         'VARCHAR(255)', // this will be 'CHARACTER VARYING' for pg!
+        allowNull:    true,
+        defaultValue: null
+      },
+      isBetaMember: {
+        type:         'TINYINT(1)', // this will be 'BOOLEAN' for pg!
+        allowNull:    false,
+        defaultValue: false
+      }
+    }
+  */
+});
+
+queryInterface.addColumn(
+  'nameOfAnExistingTable',
+  'nameOfTheNewAttribute',
+  DataTypes.STRING
+);
+
+// or
+
+queryInterface.addColumn(
+  'nameOfAnExistingTable',
+  'nameOfTheNewAttribute',
+  {
+    type: DataTypes.STRING,
+    allowNull: false
+  }
+);
+
+queryInterface.removeColumn('Person', 'signature');
+
+queryInterface.changeColumn(
+  'nameOfAnExistingTable',
+  'nameOfAnExistingAttribute',
+  {
+    type: DataTypes.FLOAT,
+    allowNull: false,
+    defaultValue: 0.0
+  }
+);
+
+queryInterface.renameColumn('Person', 'signature', 'sig');
+
+// This example will create the index person_firstname_lastname
+queryInterface.addIndex('Person', ['firstname', 'lastname']);
+
+// This example will create a unique index with the name SuperDuperIndex using the optional 'options' field.
+// Possible options:
+// - indicesType: UNIQUE|FULLTEXT|SPATIAL
+// - indexName: The name of the index. Default is __
+// - parser: For FULLTEXT columns set your parser
+// - indexType: Set a type for the index, e.g. BTREE. See the documentation of the used dialect
+// - logging: A function that receives the sql query, e.g. console.log
+queryInterface.addIndex(
+  'Person',
+  ['firstname', 'lastname'],
+  {
+    indexName: 'SuperDuperIndex',
+    indicesType: 'UNIQUE'
+  }
+);
+
+queryInterface.removeIndex('Person', 'SuperDuperIndex');
+
+// or
+
+queryInterface.removeIndex('Person', ['firstname', 'lastname']);

--- a/4/test/tsconfig.json
+++ b/4/test/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6"
+  },
+  "filesGlob": [
+    "../dist/index.d.ts",
+    "./**/*.ts"
+  ],
+  "files": [
+    "../dist/index.d.ts",
+    "connection.ts",
+    "define.ts",
+    "errors.ts",
+    "models/User.ts",
+    "models/UserGroup.ts",
+    "promise.ts",
+    "usage.ts"
+  ],
+  "atom": {
+    "rewriteTsconfig": true
+  }
+}

--- a/4/test/usage.ts
+++ b/4/test/usage.ts
@@ -1,0 +1,15 @@
+
+import {User, Group} from './models/User';
+
+async function test(): Promise<void> {
+
+  const user = await User.findOne({include: [Group]}) as User;
+  user.firstName = 'John';
+  await user.save();
+  await user.setGroup(2);
+
+  new User();
+  new User({firstName: 'John'});
+
+  const user2 = await User.create({firstName: 'John', groupId: 1}) as User;
+}

--- a/4/tsconfig.json
+++ b/4/tsconfig.json
@@ -1,0 +1,52 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "filesGlob": [
+    "typings/index.d.ts",
+    "lib/**/*.d.ts",
+    "./*.d.ts"
+  ],
+  "files": [
+    "lib/associations/base.d.ts",
+    "lib/associations/belongs-to-many.d.ts",
+    "lib/associations/belongs-to.d.ts",
+    "lib/associations/has-many.d.ts",
+    "lib/associations/has-one.d.ts",
+    "lib/associations/index.d.ts",
+    "lib/data-types.d.ts",
+    "lib/deferrable.d.ts",
+    "lib/errors.d.ts",
+    "lib/model-manager.d.ts",
+    "lib/model.d.ts",
+    "lib/promise.d.ts",
+    "lib/query-interface.d.ts",
+    "lib/sequelize.d.ts",
+    "lib/sql-string.d.ts",
+    "lib/transaction.d.ts",
+    "lib/utils.d.ts",
+    "lib/utils/parameter-validator.d.ts",
+    "lib/utils/validator-extras.d.ts",
+    "typings/index.d.ts",
+    "index.d.ts"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2,
+    "newLineCharacter": "\n",
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+  },
+  "atom": {
+    "rewriteTsconfig": true
+  }
+}

--- a/4/typings.json
+++ b/4/typings.json
@@ -1,0 +1,8 @@
+{
+  "name": "sequelize",
+  "main": "index.d.ts",
+  "dependencies": {
+    "bluebird": "registry:npm/bluebird#3.3.4+20160802085254",
+    "validator": "registry:npm/validator#4.5.1+20160723033700"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,13 +9,16 @@
     "typings": "^1.3.2"
   },
   "scripts": {
-    "postinstall": "cd 3 && typings install && typings prune",
+    "postinstall": "cd 3 && typings install && typings prune && cd ../4 && typings install && typings prune",
     "build-v3": "cd 3 && tsc -p . && typings bundle -o dist/index.d.ts",
     "test-v3": "cd 3 && tsc -p test",
-    "build+test-v3": "npm run build-v3 && npm test-v3",
-    "build": "npm run build-v3",
-    "test": "npm run test-v3",
-    "build+test": "npm run build+test-v3"
+    "build+test-v3": "npm run build-v3 && npm run test-v3",
+    "build-v4": "cd 4 && tsc -p . && typings bundle -o dist/index.d.ts",
+    "test-v4": "cd 4 && tsc -p test",
+    "build+test-v4": "npm run build-v4 && npm run test-v4",
+    "build": "npm run build-v3 && npm run build-v4",
+    "test": "npm run test-v3 && npm run build-v4",
+    "build+test": "npm run build+test-v3 && npm run build+test-v4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Moves the typings for 3 into a subdirectory (will probably require an update of the registry) and adds typings for v4.

The biggest change is that `Model` and `Instance` have been merged into one class, and instances are actually `instanceof Model`. That means many methods are now static, and the `typeof` operator is used a lot. It also means unfortunately that the first argument to `create()`, `update()` etc is now just `Object` because static methods cannot reference generic type arguments (imho that was always messy anyway). Also, until TypeScript supports polymorphic `this` for static members, `find()` etc will just return `Promise<Model>`, which means users will have to cast to their own Model, see the usage test as an example. In many other places where sequelize now uses true ES6 classes I also went ahead and use a class instead of an interface now. I also refactored the code to match the sequelize codebase 1:1.