### PR TITLE
Overhaul WhereOptions

### DIFF
--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2499,7 +2499,7 @@ declare module sequelize {
     /**
      * A hash of attributes to describe your search. See above for examples.
      */
-    where?: WhereOptions | Array<col | and | or | string> | where;
+    where?: WhereOptions;
 
   }
 
@@ -2835,20 +2835,125 @@ declare module sequelize {
 
   }
 
-  /**
-   * Where Complex nested query
-   */
-  export interface WhereNested {
-    $and: Array<WhereOptions | WhereLogic>;
-    $or: Array<WhereOptions | WhereLogic>;
+  /** The type accepted by every `where` option */
+  export type WhereOptions = WhereAttributeHash | where;
+
+  export interface WhereSubqueryOperators {
+    /**
+     * Example: `$any: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`
+     *
+     * _PG only_
+     */
+    $any?: Array<string | number>;
+
+    /** Undocumented? */
+    $all?: Array<string | number>;
   }
 
   /**
-   * Nested where Postgre Statement
+   * Operators that can be used in WhereOptions
+   *
+   * See http://docs.sequelizejs.com/en/v3/docs/querying/#operators
    */
-  export interface WherePGStatement {
-    $any: Array<string | number>;
-    $all: Array<string | number>;
+  export interface WhereOperators extends WhereSubqueryOperators {
+
+    /** Example: `$gte: 6,` becomes `>= 6` */
+    $gte?: number | string | Date;
+
+    /** Example: `$lt: 10,` becomes `< 10` */
+    $lt?: number | string | Date;
+
+    /** Example: `$lte: 10,` becomes `<= 10` */
+    $lte?: number | string | Date;
+
+    /** Example: `$ne: 20,` becomes `!= 20` */
+    $ne?: string | number | WhereOperators;
+
+    /** Example: `$not: true,` becomes `IS NOT TRUE` */
+    $not?: boolean | string | number | WhereOperators;
+
+    /** Example: `$between: [6, 10],` becomes `BETWEEN 6 AND 10` */
+    $between?: [number, number];
+
+    /** Example: `$in: [1, 2],` becomes `IN [1, 2]` */
+    $in?: Array<string | number> | literal;
+
+    /** Example: `$notIn: [1, 2],` becomes `NOT IN [1, 2]` */
+    $notIn?: Array<string | number> | literal;
+
+    /**
+     * Examples:
+     *  - `$like: '%hat',` becomes `LIKE '%hat'`
+     *  - `$like: { $any: ['cat', 'hat']}` becomes `LIKE ANY ARRAY['cat', 'hat']`
+     */
+    $like?: string | WhereSubqueryOperators;
+
+    /**
+     * Examples:
+     *  - `$notLike: '%hat'` becomes `NOT LIKE '%hat'`
+     *  - `$notLike: { $any: ['cat', 'hat']}` becomes `NOT LIKE ANY ARRAY['cat', 'hat']`
+     */
+    $notLike?: string | WhereSubqueryOperators;
+
+    /**
+     * case insensitive PG only
+     *
+     * Examples:
+     *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
+     *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
+     */
+    $ilike?: string | WhereSubqueryOperators;
+
+    /**
+     * case insensitive PG only
+     *
+     * Examples:
+     *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
+     *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
+     */
+    $iLike?: string | WhereSubqueryOperators;
+
+    /**
+     * PG array overlap operator
+     *
+     * Example: `$overlap: [1, 2]` becomes `&& [1, 2]`
+     */
+    $overlap?: [number, number];
+
+    /**
+     * PG array contains operator
+     *
+     * Example: `$contains: [1, 2]` becomes `@> [1, 2]`
+     */
+    $contains?: any[];
+
+    /**
+     * PG array contained by operator
+     *
+     * Example: `$contained: [1, 2]` becomes `<@ [1, 2]`
+     */
+    $contained?: any[];
+
+    /** Example: `$gt: 6,` becomes `> 6` */
+    $gt?: number | string | Date;
+
+    /**
+     * PG only
+     *
+     * Examples:
+     *  - `$notILike: '%hat'` becomes `NOT ILIKE '%hat'`
+     *  - `$notLike: ['cat', 'hat']` becomes `LIKE ANY ARRAY['cat', 'hat']`
+     */
+    $notILike?: string | WhereSubqueryOperators;
+
+    /** Example: `$notBetween: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
+    $notBetween?: [number, number];
+
+    /** Example: `$and: {a: 5}` becomes `AND (a = 5)` */
+    $and?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
+
+    /** Example: `$or: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */
+    $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
   }
 
   /**
@@ -2860,42 +2965,36 @@ declare module sequelize {
   }
 
   /**
-   * Logic of where statement
+   * Used for the right hand side of WhereAttributeHash.
+   * WhereAttributeHash is in there for JSON columns.
    */
-  export interface WhereLogic {
-    $ne: string | number | WhereLogic;
-    $in: Array<string | number> | literal;
-    $not: boolean | string | number | WhereOptions;
-    $notIn: Array<string | number> | literal;
-    $gte: number | string | Date;
-    $gt: number | string | Date;
-    $lte: number | string | Date;
-    $lt: number | string | Date;
-    $like: string | WherePGStatement;
-    $iLike: string | WherePGStatement;
-    $ilike: string | WherePGStatement;
-    $notLike: string | WherePGStatement;
-    $notILike: string | WherePGStatement;
-    $between: [number, number];
-    '..': [number, number];
-    $notBetween: [number, number];
-    '!..': [number, number];
-    $overlap: [number, number];
-    '&&': [number, number];
-    $contains: any;
-    '@>': any;
-    $contained: any;
-    '<@': any;
-  }
+  export type WhereValue =
+    string // literal value
+    | number // literal value
+    | WhereOperators
+    | WhereAttributeHash // for JSON columns
+    | col // reference another column
+    | and // ?
+    | or // ?
+    | WhereGeometryOptions
+    | Array<string | number>; // implicit $or
 
   /**
-   * A hash of attributes to describe your search. See above for examples.
-   *
-   * We did put Object in the end, because there where query might be a JSON Blob. It cripples a bit the
-   * typesafety, but there is no way to pass the tests if we just remove it.
+   * A hash of attributes to describe your search.
    */
-  export interface WhereOptions {
-    [field: string]: string | number | WhereLogic | WhereOptions | col | and | or | WhereGeometryOptions | Array<string | number> | Object;
+  export interface WhereAttributeHash {
+    /**
+     * Possible key values:
+     * - A simple attribute name
+     * - A nested key for JSON columns
+     *
+     *       {
+     *         "meta.audio.length": {
+     *           $gt: 20
+     *         }
+     *       }
+     */
+    [field: string]: WhereValue;
   }
 
   /**
@@ -2990,7 +3089,7 @@ declare module sequelize {
     /**
      * A hash of attributes to describe your search. See above for examples.
      */
-    where?: WhereOptions | Array<col | and | or | string> | where;
+    where?: WhereOptions;
 
     /**
      * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -3074,7 +3173,7 @@ declare module sequelize {
     /**
      * A hash of search attributes.
      */
-    where?: WhereOptions | Array<string>;
+    where?: WhereOptions;
 
     /**
      * Include options. See `find` for details
@@ -3166,7 +3265,7 @@ declare module sequelize {
     /**
      * A hash of search attributes.
      */
-    where: string | WhereOptions;
+    where: WhereOptions;
 
     /**
      * Default values to use if building a new instance
@@ -3193,7 +3292,7 @@ declare module sequelize {
     /**
      * A hash of search attributes.
      */
-    where: string | WhereOptions;
+    where: WhereOptions;
 
     /**
      * Default values to use if building a new instance
@@ -3356,7 +3455,7 @@ declare module sequelize {
      * Only used in conjunction with `truncate`.
      * Automatically restart sequences owned by columns of the truncated table
      */
-    restartIdentity: boolean;
+    restartIdentity?: boolean;
   }
 
   /**
@@ -5231,14 +5330,14 @@ declare module sequelize {
      *
      * @param args Each argument will be joined by AND
      */
-    and(...args: Array<string | Object>): and;
+    and(...args: Array<WhereOperators | WhereAttributeHash | where>): and;
 
     /**
      * An OR query
      *
      * @param args Each argument will be joined by OR
      */
-    or(...args: Array<string | Object>): or;
+    or(...args: Array<WhereOperators | WhereAttributeHash | where>): or;
 
     /**
      * Creates an object representing nested where conditions for postgres's json data-type.
@@ -5806,7 +5905,7 @@ declare module sequelize {
   }
 
   export interface and {
-    args: Array<any>;
+    $and: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
   }
 
   export interface andStatic {
@@ -5819,7 +5918,7 @@ declare module sequelize {
   }
 
   export interface or {
-    args: Array<any>;
+    $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
   }
 
   export interface orStatic {

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2836,7 +2836,7 @@ declare module sequelize {
   }
 
   /** The type accepted by every `where` option */
-  export type WhereOptions = WhereAttributeHash | where;
+  export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | where;
 
   export interface WhereSubqueryOperators {
     /**
@@ -2956,6 +2956,14 @@ declare module sequelize {
     $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
   }
 
+  export interface OrOperator {
+    $or: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash>;
+  }
+
+  export interface AndOperator {
+    $or: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash>;
+  }
+
   /**
    * Where Geometry Options
    */
@@ -2974,8 +2982,8 @@ declare module sequelize {
     | WhereOperators
     | WhereAttributeHash // for JSON columns
     | col // reference another column
-    | and // ?
-    | or // ?
+    | AndOperator
+    | OrOperator
     | WhereGeometryOptions
     | Array<string | number>; // implicit $or
 
@@ -5330,14 +5338,14 @@ declare module sequelize {
      *
      * @param args Each argument will be joined by AND
      */
-    and(...args: Array<WhereOperators | WhereAttributeHash | where>): and;
+    and(...args: Array<WhereOperators | WhereAttributeHash>): AndOperator;
 
     /**
      * An OR query
      *
      * @param args Each argument will be joined by OR
      */
-    or(...args: Array<WhereOperators | WhereAttributeHash | where>): or;
+    or(...args: Array<WhereOperators | WhereAttributeHash>): OrOperator;
 
     /**
      * Creates an object representing nested where conditions for postgres's json data-type.
@@ -5902,33 +5910,6 @@ declare module sequelize {
      * @param val
      */
     new (val: any): literal;
-  }
-
-  export interface and {
-    $and: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
-  }
-
-  export interface andStatic {
-    /**
-     * An AND query
-     *
-     * @param args Each argument will be joined by AND
-     */
-    new (...args: Array<string | Object>): and;
-  }
-
-  export interface or {
-    $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | where>;
-  }
-
-  export interface orStatic {
-    /**
-     * An OR query
-     * @see {Model#find}
-     *
-     * @param args Each argument will be joined by OR
-     */
-    new (...args: Array<String | Object>): or;
   }
 
   export interface json {

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2835,8 +2835,11 @@ declare module sequelize {
 
   }
 
-  /** The type accepted by every `where` option */
-  export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | where;
+  /**
+   * The type accepted by every `where` option
+   * The `Array<string | number>` is to support string with replacements, like `['id > ?', 25]`
+   */
+  export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | where | Array<string | number>;
 
   export interface WhereSubqueryOperators {
     /**

--- a/3/test/tsconfig.json
+++ b/3/test/tsconfig.json
@@ -11,7 +11,8 @@
     "./cast.ts",
     "./promise.ts",
     "./query-interface.ts",
-    "./test.ts"
+    "./test.ts",
+    "./where.ts"
   ],
   "atom": {
     "rewriteTsconfig": true

--- a/3/test/where.ts
+++ b/3/test/where.ts
@@ -1,0 +1,161 @@
+
+import * as Sequelize from 'sequelize';
+
+let Model: Sequelize.Model<any, any>;
+
+let where: Sequelize.WhereOptions;
+
+// From http://docs.sequelizejs.com/en/v3/docs/querying/
+
+// Operators
+
+let operators: Sequelize.WhereOperators = {
+  $and: { a: 5 },                 // AND (a = 5)
+  $or: [{ a: 5 }, { a: 6 }],      // (a = 5 OR a = 6)
+  $gt: 6,                         // > 6
+  $gte: 6,                        // >= 6
+  $lt: 10,                        // < 10
+  $lte: 10,                       // <= 10
+  $ne: 20,                        // != 20
+  $not: true,                     // IS NOT TRUE
+  $between: [6, 10],              // BETWEEN 6 AND 10
+  $notBetween: [11, 15],          // NOT BETWEEN 11 AND 15
+  $in: [1, 2],                    // IN [1, 2]
+  $notIn: [1, 2],                 // NOT IN [1, 2]
+  $like: '%hat',                  // LIKE '%hat'
+  $notLike: '%hat',               // NOT LIKE '%hat'
+  $iLike: '%hat',                 // ILIKE '%hat' (case insensitive) (PG only)
+  $notILike: '%hat',              // NOT ILIKE '%hat'  (PG only)
+  $overlap: [1, 2],               // && [1, 2] (PG array overlap operator)
+  $contains: [1, 2],              // @> [1, 2] (PG array contains operator)
+  $contained: [1, 2],             // <@ [1, 2] (PG array contained by operator)
+  $any: [2, 3]                    // ANY ARRAY[2, 3]::INTEGER (PG only)
+};
+
+operators = {
+  $like: { $any: ['cat', 'hat'] } // LIKE ANY ARRAY['cat', 'hat'] - also works for iLike and notLike
+};
+
+// Combinations
+
+where = {
+  rank: {
+    $or: {
+      $lt: 1000,
+      $eq: null
+    }
+  }
+};
+// rank < 1000 OR rank IS NULL
+
+where = {
+  createdAt: {
+    $lt: new Date(),
+    $gt: new Date(Date.now() - 24 * 60 * 60 * 1000)
+  }
+};
+// createdAt < [timestamp] AND createdAt > [timestamp]
+
+where = {
+  $or: [
+    {
+      title: {
+        $like: 'Boat%'
+      }
+    },
+    {
+      description: {
+        $like: '%boat%'
+      }
+    }
+  ]
+};
+// title LIKE 'Boat%' OR description LIKE '%boat%'
+
+// Containment
+
+where = {
+  'meta': {
+    $contains: {
+      site: {
+        url: 'http://google.com'
+      }
+    }
+  }
+};
+
+// Relations / Associations
+// Find all projects with a least one task where task.state === project.task
+Model.findAll({
+    include: [{
+        model: Model,
+        where: { state: Sequelize.col('project.state') }
+    }]
+});
+
+Model.find({
+  where,
+  include: [
+    {
+      model: Model,
+      where,
+      include: [
+        { model: Model, where }
+      ]
+    }
+  ]
+});
+Model.destroy({ where });
+Model.update({ hi: 1 }, { where });
+
+// From http://docs.sequelizejs.com/en/v3/docs/models-usage/
+
+// Complex filtering / NOT queries
+
+where = {
+  name: 'a project',
+  $or: [
+    { id: [1, 2, 3] },
+    { id: { $gt: 10 } }
+  ]
+};
+
+where = {
+  name: 'a project',
+  id: {
+    $or: [
+      [1, 2, 3],
+      { $gt: 10 }
+    ]
+  }
+};
+
+// $not example:
+where = {
+  name: 'a project',
+  $not: [
+    { id: [1, 2, 3] },
+    { array: { $contains: [3, 4, 5] } }
+  ]
+};
+
+// JSONB
+
+// Nested object
+
+where = {
+  meta: {
+    video: {
+      url: {
+        $ne: null
+      }
+    }
+  }
+};
+
+// Nested key
+where = {
+  'meta.audio.length': {
+    $gt: 20
+  }
+};

--- a/3/test/where.ts
+++ b/3/test/where.ts
@@ -36,16 +36,21 @@ operators = {
   $like: { $any: ['cat', 'hat'] } // LIKE ANY ARRAY['cat', 'hat'] - also works for iLike and notLike
 };
 
-// Combinations
+where = Sequelize.and();
+
+where = Sequelize.or();
+
+where = {$and: []};
 
 where = {
-  rank: {
-    $or: {
-      $lt: 1000,
-      $eq: null
-    }
-  }
+  rank: Sequelize.and({$lt: 1000}, {$eq: null})
 };
+
+where = {
+  rank: Sequelize.or({$lt: 1000}, {$eq: null})
+};
+
+// Combinations
 // rank < 1000 OR rank IS NULL
 
 where = {

--- a/3/test/where.ts
+++ b/3/test/where.ts
@@ -115,6 +115,62 @@ Model.update({ hi: 1 }, { where });
 
 // From http://docs.sequelizejs.com/en/v3/docs/models-usage/
 
+
+// find multiple entries
+Model.findAll().then(function(projects) {
+  // projects will be an array of all Model instances
+});
+
+// also possible:
+Model.all().then(function(projects) {
+  // projects will be an array of all Model instances
+});
+
+// search for specific attributes - hash usage
+Model.findAll({ where: { name: 'A Model' } }).then(function(projects) {
+  // projects will be an array of Model instances with the specified name
+});
+
+// search with string replacements
+Model.findAll({ where: ['id > ?', 25] }).then(function(projects) {
+  // projects will be an array of Models having a greater id than 25
+});
+
+// search within a specific range
+Model.findAll({ where: { id: [1,2,3] } }).then(function(projects) {
+  // projects will be an array of Models having the id 1, 2 or 3
+  // this is actually doing an IN query
+});
+
+Model.findAll({
+  where: {
+    id: <Sequelize.WhereOperators>{ // casting here to check a missing operator is not accepted as field name
+      $and: {a: 5},          // AND (a = 5)
+      $or: [{a: 5}, {a: 6}], // (a = 5 OR a = 6)
+      $gt: 6,                // id > 6
+      $gte: 6,               // id >= 6
+      $lt: 10,               // id < 10
+      $lte: 10,              // id <= 10
+      $ne: 20,               // id != 20
+      $between: [6, 10],     // BETWEEN 6 AND 10
+      $notBetween: [11, 15], // NOT BETWEEN 11 AND 15
+      $in: [1, 2],           // IN [1, 2]
+      $notIn: [1, 2],        // NOT IN [1, 2]
+      $like: '%hat',         // LIKE '%hat'
+      $notLike: '%hat',      // NOT LIKE '%hat'
+      $iLike: '%hat',        // ILIKE '%hat' (case insensitive)  (PG only)
+      $notILike: '%hat',     // NOT ILIKE '%hat'  (PG only)
+      $overlap: [1, 2],      // && [1, 2] (PG array overlap operator)
+      $contains: [1, 2],     // @> [1, 2] (PG array contains operator)
+      $contained: [1, 2],    // <@ [1, 2] (PG array contained by operator)
+      $any: [2, 3]           // ANY ARRAY[2, 3]::INTEGER (PG only)
+    },
+    status: {
+      $not: false            // status NOT FALSE
+    }
+  }
+});
+
 // Complex filtering / NOT queries
 
 where = {

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -72,19 +72,25 @@ export interface ScopeOptions {
 
 }
 
-/** The type accepted by every `where` option */
-export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | Where;
+/**
+ * The type accepted by every `where` option
+ *
+ * The `Array<string | number>` is to support string with replacements, like `['id > ?', 25]`
+ */
+export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | Where | Array<string | number>;
 
-export interface WhereSubqueryOperators {
-  /**
-   * Example: `$any: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`
-   *
-   * _PG only_
-   */
-  $any?: Array<string | number>;
+/**
+ * Example: `$any: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`
+ *
+ * _PG only_
+ */
+export interface AnyOperator {
+  $any: Array<string | number>;
+}
 
-  /** Undocumented? */
-  $all?: Array<string | number>;
+/** Undocumented? */
+export interface AllOperator {
+  $all: Array<string | number>;
 }
 
 /**
@@ -92,7 +98,14 @@ export interface WhereSubqueryOperators {
  *
  * See http://docs.sequelizejs.com/en/v3/docs/querying/#operators
  */
-export interface WhereOperators extends WhereSubqueryOperators {
+export interface WhereOperators {
+
+  /**
+   * Example: `$any: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`
+   *
+   * _PG only_
+   */
+  $any?: Array<string | number>;
 
   /** Example: `$gte: 6,` becomes `>= 6` */
   $gte?: number | string | Date;
@@ -123,14 +136,14 @@ export interface WhereOperators extends WhereSubqueryOperators {
    *  - `$like: '%hat',` becomes `LIKE '%hat'`
    *  - `$like: { $any: ['cat', 'hat']}` becomes `LIKE ANY ARRAY['cat', 'hat']`
    */
-  $like?: string | WhereSubqueryOperators;
+  $like?: string | AnyOperator | AllOperator;
 
   /**
    * Examples:
    *  - `$notLike: '%hat'` becomes `NOT LIKE '%hat'`
    *  - `$notLike: { $any: ['cat', 'hat']}` becomes `NOT LIKE ANY ARRAY['cat', 'hat']`
    */
-  $notLike?: string | WhereSubqueryOperators;
+  $notLike?: string | AnyOperator | AllOperator;
 
   /**
    * case insensitive PG only
@@ -139,7 +152,7 @@ export interface WhereOperators extends WhereSubqueryOperators {
    *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
    *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
    */
-  $ilike?: string | WhereSubqueryOperators;
+  $ilike?: string | AnyOperator | AllOperator;
 
   /**
    * case insensitive PG only
@@ -148,7 +161,7 @@ export interface WhereOperators extends WhereSubqueryOperators {
    *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
    *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
    */
-  $iLike?: string | WhereSubqueryOperators;
+  $iLike?: string | AnyOperator | AllOperator;
 
   /**
    * PG array overlap operator
@@ -181,7 +194,7 @@ export interface WhereOperators extends WhereSubqueryOperators {
    *  - `$notILike: '%hat'` becomes `NOT ILIKE '%hat'`
    *  - `$notLike: ['cat', 'hat']` becomes `LIKE ANY ARRAY['cat', 'hat']`
    */
-  $notILike?: string | WhereSubqueryOperators;
+  $notILike?: string | AnyOperator | AllOperator;
 
   /** Example: `$notBetween: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
   $notBetween?: [number, number];

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -72,20 +72,125 @@ export interface ScopeOptions {
 
 }
 
-/**
- * Where Complex nested query
- */
-export interface WhereNested {
-  $and: Array<WhereAttributeHash | WhereLogic>;
-  $or: Array<WhereAttributeHash | WhereLogic>;
+/** The type accepted by every `where` option */
+export type WhereOptions = WhereAttributeHash | Where;
+
+export interface WhereSubqueryOperators {
+  /**
+   * Example: `$any: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`
+   *
+   * _PG only_
+   */
+  $any?: Array<string | number>;
+
+  /** Undocumented? */
+  $all?: Array<string | number>;
 }
 
 /**
- * Nested where Postgre Statement
+ * Operators that can be used in WhereOptions
+ *
+ * See http://docs.sequelizejs.com/en/v3/docs/querying/#operators
  */
-export interface WherePGStatement {
-  $any: Array<string | number>;
-  $all: Array<string | number>;
+export interface WhereOperators extends WhereSubqueryOperators {
+
+  /** Example: `$gte: 6,` becomes `>= 6` */
+  $gte?: number | string | Date;
+
+  /** Example: `$lt: 10,` becomes `< 10` */
+  $lt?: number | string | Date;
+
+  /** Example: `$lte: 10,` becomes `<= 10` */
+  $lte?: number | string | Date;
+
+  /** Example: `$ne: 20,` becomes `!= 20` */
+  $ne?: string | number | WhereOperators;
+
+  /** Example: `$not: true,` becomes `IS NOT TRUE` */
+  $not?: boolean | string | number | WhereOperators;
+
+  /** Example: `$between: [6, 10],` becomes `BETWEEN 6 AND 10` */
+  $between?: [number, number];
+
+  /** Example: `$in: [1, 2],` becomes `IN [1, 2]` */
+  $in?: Array<string | number> | Literal;
+
+  /** Example: `$notIn: [1, 2],` becomes `NOT IN [1, 2]` */
+  $notIn?: Array<string | number> | Literal;
+
+  /**
+   * Examples:
+   *  - `$like: '%hat',` becomes `LIKE '%hat'`
+   *  - `$like: { $any: ['cat', 'hat']}` becomes `LIKE ANY ARRAY['cat', 'hat']`
+   */
+  $like?: string | WhereSubqueryOperators;
+
+  /**
+   * Examples:
+   *  - `$notLike: '%hat'` becomes `NOT LIKE '%hat'`
+   *  - `$notLike: { $any: ['cat', 'hat']}` becomes `NOT LIKE ANY ARRAY['cat', 'hat']`
+   */
+  $notLike?: string | WhereSubqueryOperators;
+
+  /**
+   * case insensitive PG only
+   *
+   * Examples:
+   *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
+   *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
+   */
+  $ilike?: string | WhereSubqueryOperators;
+
+  /**
+   * case insensitive PG only
+   *
+   * Examples:
+   *  - `$iLike: '%hat'` becomes `ILIKE '%hat'`
+   *  - `$iLike: { $any: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
+   */
+  $iLike?: string | WhereSubqueryOperators;
+
+  /**
+   * PG array overlap operator
+   *
+   * Example: `$overlap: [1, 2]` becomes `&& [1, 2]`
+   */
+  $overlap?: [number, number];
+
+  /**
+   * PG array contains operator
+   *
+   * Example: `$contains: [1, 2]` becomes `@> [1, 2]`
+   */
+  $contains?: any[];
+
+  /**
+   * PG array contained by operator
+   *
+   * Example: `$contained: [1, 2]` becomes `<@ [1, 2]`
+   */
+  $contained?: any[];
+
+  /** Example: `$gt: 6,` becomes `> 6` */
+  $gt?: number | string | Date;
+
+  /**
+   * PG only
+   *
+   * Examples:
+   *  - `$notILike: '%hat'` becomes `NOT ILIKE '%hat'`
+   *  - `$notLike: ['cat', 'hat']` becomes `LIKE ANY ARRAY['cat', 'hat']`
+   */
+  $notILike?: string | WhereSubqueryOperators;
+
+  /** Example: `$notBetween: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
+  $notBetween?: [number, number];
+
+  /** Example: `$and: {a: 5}` becomes `AND (a = 5)` */
+  $and?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | Where>;
+
+  /** Example: `$or: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */
+  $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | Where>;
 }
 
 /**
@@ -97,44 +202,37 @@ export interface WhereGeometryOptions {
 }
 
 /**
- * Logic of where statement
+ * Used for the right hand side of WhereAttributeHash.
+ * WhereAttributeHash is in there for JSON columns.
  */
-export interface WhereLogic {
-  $ne: string | number | WhereLogic;
-  $in: Array<string | number> | Literal;
-  $not: boolean | string | number | WhereAttributeHash;
-  $notIn: Array<string | number> | Literal;
-  $gte: number | string | Date;
-  $gt: number | string | Date;
-  $lte: number | string | Date;
-  $lt: number | string | Date;
-  $like: string | WherePGStatement;
-  $iLike: string | WherePGStatement;
-  $ilike: string | WherePGStatement;
-  $notLike: string | WherePGStatement;
-  $notILike: string | WherePGStatement;
-  $between: [number, number];
-  '..': [number, number];
-  $notBetween: [number, number];
-  '!..': [number, number];
-  $overlap: [number, number];
-  '&&': [number, number];
-  $contains: any;
-  '@>': any;
-  $contained: any;
-  '<@': any;
-}
+export type WhereValue =
+  string // literal value
+  | number // literal value
+  | WhereOperators
+  | WhereAttributeHash // for JSON columns
+  | Col // reference another column
+  | And // ?
+  | Or // ?
+  | WhereGeometryOptions
+  | Array<string | number>; // implicit $or
 
 /**
- * A hash of attributes to describe your search. See above for examples.
- *
- * We did put Object in the end, because there where query might be a JSON Blob. It cripples a bit the
- * typesafety, but there is no way to pass the tests if we just remove it.
+ * A hash of attributes to describe your search.
  */
 export interface WhereAttributeHash {
-  [field: string]: string | number | WhereLogic | WhereAttributeHash | Col | And | Or | WhereGeometryOptions | Array<string | number> | Object;
+  /**
+   * Possible key values:
+   * - A simple attribute name
+   * - A nested key for JSON columns
+   *
+   *       {
+   *         "meta.audio.length": {
+   *           $gt: 20
+   *         }
+   *       }
+   */
+  [field: string]: WhereValue;
 }
-
 /**
  * Through options for Include Options
  */
@@ -219,8 +317,6 @@ export type FindAttributeOptions =
     exclude?: Array<string>;
     include: Array<string | [string | Fn, string]>;
   };
-
-export type WhereOptions = WhereAttributeHash | Array<Col | And | Or | string> | Where;
 
 /**
  * Options that are passed to any model creating a SELECT query

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1,6 +1,6 @@
 
 import {Promise} from './promise';
-import {Col, Fn, Literal, Where, And, Or} from './utils';
+import {Col, Fn, Literal, Where} from './utils';
 import {SyncOptions} from './sequelize';
 import {QueryOptions} from './query-interface';
 import {Transaction} from './transaction';
@@ -73,7 +73,7 @@ export interface ScopeOptions {
 }
 
 /** The type accepted by every `where` option */
-export type WhereOptions = WhereAttributeHash | Where;
+export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | Where;
 
 export interface WhereSubqueryOperators {
   /**
@@ -185,12 +185,16 @@ export interface WhereOperators extends WhereSubqueryOperators {
 
   /** Example: `$notBetween: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
   $notBetween?: [number, number];
+}
 
-  /** Example: `$and: {a: 5}` becomes `AND (a = 5)` */
-  $and?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | Where>;
+/** Example: `$or: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */
+export interface OrOperator {
+  $or: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash>;
+}
 
-  /** Example: `$or: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */
-  $or?: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash | Where>;
+/** Example: `$and: {a: 5}` becomes `AND (a = 5)` */
+export interface AndOperator {
+  $and: WhereOperators | WhereAttributeHash | Array<WhereOperators | WhereAttributeHash>;
 }
 
 /**
@@ -211,8 +215,8 @@ export type WhereValue =
   | WhereOperators
   | WhereAttributeHash // for JSON columns
   | Col // reference another column
-  | And // ?
-  | Or // ?
+  | OrOperator
+  | AndOperator
   | WhereGeometryOptions
   | Array<string | number>; // implicit $or
 

--- a/4/lib/sequelize.d.ts
+++ b/4/lib/sequelize.d.ts
@@ -1,6 +1,6 @@
 
 import {DataType} from './data-types';
-import {And, Or, Literal, Json, Where, Col, Cast, Fn} from './utils';
+import {Literal, Json, Where, Col, Cast, Fn} from './utils';
 import {Transaction, TransactionOptions} from './transaction';
 import {QueryInterface, QueryOptions} from './query-interface';
 import {DataTypes} from './data-types';
@@ -16,7 +16,11 @@ import {
   InstanceDestroyOptions,
   UpdateOptions,
   BulkCreateOptions,
-  FindOptions
+  FindOptions,
+  WhereAttributeHash,
+  WhereOperators,
+  AndOperator,
+  OrOperator
 } from './model';
 
 
@@ -305,14 +309,14 @@ export class Sequelize {
    *
    * @param args Each argument will be joined by AND
    */
-  static and(...args: Array<string | Object>): And;
+  static and(...args: Array<WhereOperators | WhereAttributeHash>): AndOperator;
 
   /**
    * An OR query
    *
    * @param args Each argument will be joined by OR
    */
-  static or(...args: Array<string | Object>): Or;
+  static or(...args: Array<WhereOperators | WhereAttributeHash>): OrOperator;
 
   /**
    * Creates an object representing nested where conditions for postgres's json data-type.

--- a/4/lib/utils.d.ts
+++ b/4/lib/utils.d.ts
@@ -109,16 +109,6 @@ export class Where {
   constructor(attr: Object, logic: string | Object);
 }
 
-export class And {
-  args: any[];
-  constructor(...args: Array<string | Object>);
-}
-
-export class Or {
-  args: any[];
-  constructor(...args: Array<string | Object>);
-}
-
 export const validateParameter: typeof parameterValidator;
 export function formatReferences(obj: any): any;
 

--- a/4/test/tsconfig.json
+++ b/4/test/tsconfig.json
@@ -15,7 +15,8 @@
     "models/User.ts",
     "models/UserGroup.ts",
     "promise.ts",
-    "usage.ts"
+    "usage.ts",
+    "where.ts"
   ],
   "atom": {
     "rewriteTsconfig": true

--- a/4/test/where.ts
+++ b/4/test/where.ts
@@ -1,0 +1,161 @@
+
+import {Model, Sequelize, WhereOptions, WhereOperators} from 'sequelize';
+
+class MyModel extends Model { }
+
+let where: WhereOptions;
+
+// From http://docs.sequelizejs.com/en/v4/docs/querying/
+
+// Operators
+
+let operators: WhereOperators = {
+  $and: { a: 5 },                 // AND (a = 5)
+  $or: [{ a: 5 }, { a: 6 }],      // (a = 5 OR a = 6)
+  $gt: 6,                         // > 6
+  $gte: 6,                        // >= 6
+  $lt: 10,                        // < 10
+  $lte: 10,                       // <= 10
+  $ne: 20,                        // != 20
+  $not: true,                     // IS NOT TRUE
+  $between: [6, 10],              // BETWEEN 6 AND 10
+  $notBetween: [11, 15],          // NOT BETWEEN 11 AND 15
+  $in: [1, 2],                    // IN [1, 2]
+  $notIn: [1, 2],                 // NOT IN [1, 2]
+  $like: '%hat',                  // LIKE '%hat'
+  $notLike: '%hat',               // NOT LIKE '%hat'
+  $iLike: '%hat',                 // ILIKE '%hat' (case insensitive) (PG only)
+  $notILike: '%hat',              // NOT ILIKE '%hat'  (PG only)
+  $overlap: [1, 2],               // && [1, 2] (PG array overlap operator)
+  $contains: [1, 2],              // @> [1, 2] (PG array contains operator)
+  $contained: [1, 2],             // <@ [1, 2] (PG array contained by operator)
+  $any: [2, 3]                    // ANY ARRAY[2, 3]::INTEGER (PG only)
+};
+
+operators = {
+  $like: { $any: ['cat', 'hat'] } // LIKE ANY ARRAY['cat', 'hat'] - also works for iLike and notLike
+};
+
+// Combinations
+
+where = {
+  rank: {
+    $or: {
+      $lt: 1000,
+      $eq: null
+    }
+  }
+};
+// rank < 1000 OR rank IS NULL
+
+where = {
+  createdAt: {
+    $lt: new Date(),
+    $gt: new Date(Date.now() - 24 * 60 * 60 * 1000)
+  }
+};
+// createdAt < [timestamp] AND createdAt > [timestamp]
+
+where = {
+  $or: [
+    {
+      title: {
+        $like: 'Boat%'
+      }
+    },
+    {
+      description: {
+        $like: '%boat%'
+      }
+    }
+  ]
+};
+// title LIKE 'Boat%' OR description LIKE '%boat%'
+
+// Containment
+
+where = {
+  'meta': {
+    $contains: {
+      site: {
+        url: 'http://google.com'
+      }
+    }
+  }
+};
+
+// Relations / Associations
+// Find all projects with a least one task where task.state === project.task
+MyModel.findAll({
+  include: [{
+    model: MyModel,
+    where: { state: Sequelize.col('project.state') }
+  }]
+});
+
+MyModel.find({
+  where,
+  include: [
+    {
+      model: MyModel,
+      where,
+      include: [
+        { model: MyModel, where }
+      ]
+    }
+  ]
+});
+MyModel.destroy({ where });
+MyModel.update({ hi: 1 }, { where });
+
+// From http://docs.sequelizejs.com/en/v4/docs/models-usage/
+
+// Complex filtering / NOT queries
+
+where = {
+  name: 'a project',
+  $or: [
+    { id: [1, 2, 3] },
+    { id: { $gt: 10 } }
+  ]
+};
+
+where = {
+  name: 'a project',
+  id: {
+    $or: [
+      [1, 2, 3],
+      { $gt: 10 }
+    ]
+  }
+};
+
+// $not example:
+where = {
+  name: 'a project',
+  $not: [
+    { id: [1, 2, 3] },
+    { array: { $contains: [3, 4, 5] } }
+  ]
+};
+
+// JSONB
+
+// Nested object
+
+where = {
+  meta: {
+    video: {
+      url: {
+        $ne: null
+      }
+    }
+  }
+};
+
+// Nested key
+where = {
+  'meta.audio.length': {
+    $gt: 20
+  }
+};

--- a/4/test/where.ts
+++ b/4/test/where.ts
@@ -1,5 +1,5 @@
 
-import {Model, Sequelize, WhereOptions, WhereOperators} from 'sequelize';
+import {Model, Sequelize, WhereOptions, WhereOperators, AndOperator, OrOperator} from 'sequelize';
 
 class MyModel extends Model { }
 
@@ -9,9 +9,15 @@ let where: WhereOptions;
 
 // Operators
 
+let and: AndOperator = {
+  $and: { a: 5 }                  // AND (a = 5)
+};
+
+let or: OrOperator = {
+  $or: [{ a: 5 }, { a: 6 }]       // (a = 5 OR a = 6)
+};
+
 let operators: WhereOperators = {
-  $and: { a: 5 },                 // AND (a = 5)
-  $or: [{ a: 5 }, { a: 6 }],      // (a = 5 OR a = 6)
   $gt: 6,                         // > 6
   $gte: 6,                        // >= 6
   $lt: 10,                        // < 10
@@ -37,6 +43,23 @@ operators = {
 };
 
 // Combinations
+
+Model.find({ where: or });
+Model.find({ where: and });
+
+where = Sequelize.and();
+
+where = Sequelize.or();
+
+where = { $and: [] };
+
+where = {
+  rank: Sequelize.and({ $lt: 1000 }, { $eq: null })
+};
+
+where = {
+  rank: Sequelize.or({ $lt: 1000 }, { $eq: null })
+};
 
 where = {
   rank: {

--- a/4/test/where.ts
+++ b/4/test/where.ts
@@ -133,6 +133,61 @@ MyModel.update({ hi: 1 }, { where });
 
 // From http://docs.sequelizejs.com/en/v4/docs/models-usage/
 
+// find multiple entries
+MyModel.findAll().then(function(projects) {
+  // projects will be an array of all MyModel instances
+});
+
+// also possible:
+MyModel.all().then(function(projects) {
+  // projects will be an array of all MyModel instances
+});
+
+// search for specific attributes - hash usage
+MyModel.findAll({ where: { name: 'A MyModel' } }).then(function(projects) {
+  // projects will be an array of MyModel instances with the specified name
+});
+
+// search with string replacements
+MyModel.findAll({ where: ['id > ?', 25] }).then(function(projects) {
+  // projects will be an array of MyModels having a greater id than 25
+});
+
+// search within a specific range
+MyModel.findAll({ where: { id: [1, 2, 3] } }).then(function(projects) {
+  // projects will be an array of MyModels having the id 1, 2 or 3
+  // this is actually doing an IN query
+});
+
+MyModel.findAll({
+  where: {
+    id: <WhereOperators>{ // casting here to check a missing operator is not accepted as field name
+      $and: {a: 5},          // AND (a = 5)
+      $or: [{a: 5}, {a: 6}], // (a = 5 OR a = 6)
+      $gt: 6,                // id > 6
+      $gte: 6,               // id >= 6
+      $lt: 10,               // id < 10
+      $lte: 10,              // id <= 10
+      $ne: 20,               // id != 20
+      $between: [6, 10],     // BETWEEN 6 AND 10
+      $notBetween: [11, 15], // NOT BETWEEN 11 AND 15
+      $in: [1, 2],           // IN [1, 2]
+      $notIn: [1, 2],        // NOT IN [1, 2]
+      $like: '%hat',         // LIKE '%hat'
+      $notLike: '%hat',      // NOT LIKE '%hat'
+      $iLike: '%hat',        // ILIKE '%hat' (case insensitive)  (PG only)
+      $notILike: '%hat',     // NOT ILIKE '%hat'  (PG only)
+      $overlap: [1, 2],      // && [1, 2] (PG array overlap operator)
+      $contains: [1, 2],     // @> [1, 2] (PG array contains operator)
+      $contained: [1, 2],    // <@ [1, 2] (PG array contained by operator)
+      $any: [2, 3]           // ANY ARRAY[2, 3]::INTEGER (PG only)
+    },
+    status: {
+      $not: false            // status NOT FALSE
+    }
+  }
+});
+
 // Complex filtering / NOT queries
 
 where = {


### PR DESCRIPTION
This completely overhauls `WhereOptions`. There is now `WhereAttributesHash` and `WhereOperators`. I also added a test file with all examples I could find in the docs. We also don't accept `Object` anymore (don't worry, JSON is tested). Also added docs for all operators.

You can now even get IntelliSense if you help the compiler by casting:
```ts
Model.find({
  where: {
    myAttribute: <WhereOperators>{
      // get IntelliSense for available operators inside here!
      $any: [1, 2]
    }
  }
});
```