### PR TITLE
Typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 *.js
 *.log
+typedoc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
 node_js:
-- '4.1'
+ - '4.1'
 script:
-- npm run build
-- npm test
+ - npm run build
+ - npm test
+before_deploy:
+ - npm run typedoc
+deploy:
+  provider: surge
+  project: ./typedoc/
+  domain: typed-bignumber.surge.sh
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_deploy:
 deploy:
   provider: surge
   project: ./typedoc/
-  domain: typed-bignumber.surge.sh
+  domain: typed-sequelize.surge.sh
   skip_cleanup: true

--- a/3/README.md
+++ b/3/README.md
@@ -1,4 +1,7 @@
 # Typed Sequelize@3
+[![Build Status](https://travis-ci.org/louy/typed-sequelize.svg?branch=master)](https://travis-ci.org/louy/typed-sequelize)
+
+## [API Documentation](http://typed-sequelize.surge.sh/v3)
 
 ## Usage
 

--- a/3/docs_index.md
+++ b/3/docs_index.md
@@ -1,0 +1,55 @@
+
+_Start typing to search_
+
+## API
+<ul class="tsd-index-list" style="list-style: none">
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.connection.html">Sequelize</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.model.html">Model</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.instance.html">Instance</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.hooks.html">Hooks</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.hooks.html">Associations</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.transaction.html">Transaction</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/datatypes.html">DataTypes</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.errors.html">Errors</a></li>
+  <li class="tsd-kind-interface"><a class="tsd-kind-icon" href="interfaces/sequelize.deferrable.html">Deferrable</a></li>
+</ul>
+
+## Example
+
+```ts
+// models/Thing.ts
+import * as Sequelize from 'sequelize';
+import sequelize from '../connection'; // A Sequelize instance
+
+/**
+ * Interface used to create/update an instance (passed to create/update)
+ */
+export interface Thing {
+  id?: number;
+  name?: string;
+}
+
+/**
+ * The actual instance class
+ */
+export interface ThingInstance extends Sequelize.Instance<ThingInstance, Thing> {
+  id: number;
+  name: string;
+
+  // you should add all instance methods here
+  doSomething(): any;
+}
+
+/**
+ * Your Model
+ */
+export const Thing = sequelize.define<ThingInstance, Thing>('Thing', {
+  name: Sequelize.STRING,
+}, {
+  instanceMethods: {
+    doSomething() {
+      // whatever...
+    }
+  }
+});
+```

--- a/4/README.md
+++ b/4/README.md
@@ -3,6 +3,8 @@
 
 Typescript Typings for [Sequelize](http://sequelizejs.com).
 
+## [API Documentation](http://typed-sequelize.surge.sh/v4)
+
 ## Installation
 
 ```bash
@@ -11,4 +13,64 @@ typings install --save sequelize@4
 
 ## Usage
 
-See the [test folder](./test)
+```ts
+import {
+  Model,
+  FindOptions,
+  STRING,
+  BelongsTo,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  BelongsToCreateAssociationMixin
+} from 'sequelize';
+import {sequelize} from '../connection';
+
+export class User extends Model {
+
+  static associations: {
+    group: BelongsTo
+  };
+
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  // mixins for association (optional)
+  groupId: number;
+  group: UserGroup;
+  getGroup: BelongsToGetAssociationMixin<UserGroup>;
+  setGroup: BelongsToSetAssociationMixin<UserGroup, number>;
+  createGroup: BelongsToCreateAssociationMixin<UserGroup>;
+}
+
+User.init({
+  username: STRING,
+  firstName: STRING,
+  lastName: STRING
+}, {}, sequelize.modelManager);
+
+// associate
+// it is important to import _after_ the model above is already exported so the circular reference works.
+import {UserGroup} from './UserGroup';
+User.belongsTo(UserGroup, {as: 'group', foreignKey: 'groupId'});
+```
+
+```ts
+import {User, Group} from './models/User';
+
+async function test() {
+
+  const user = await User.findOne({include: [Group]}) as User;
+  user.firstName = 'John';
+  await user.save();
+  await user.setGroup(2);
+
+  new User();
+  new User({firstName: 'John'});
+
+  const user2 = await User.create({firstName: 'John', groupId: 1}) as User;
+}
+```

--- a/4/docs_index.md
+++ b/4/docs_index.md
@@ -1,0 +1,89 @@
+
+_Start typing to search_
+
+## API
+<ul class="tsd-index-list" style="list-style: none">
+  <li class="tsd-kind-class"><a class="tsd-kind-icon" href="classes/_lib_sequelize_d_.sequelize.html">Sequelize</a></li>
+  <li class="tsd-kind-class"><a class="tsd-kind-icon" href="classses/_lib_model_d_.model.html">Model</a></li>
+  <li class="tsd-kind-class"><a class="tsd-kind-icon" href="classes/_lib_transaction_d_.transaction.html">Transaction</a></li>
+  <li class="tsd-kind-class"><a class="tsd-kind-icon" href="classes/_lib_query_interface_d_.queryinterface.html">QueryInterface</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_data_types_d_.html">DataTypes</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_errors_d_.html">Errors</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_deferrable_d_.html">Deferrable</a></li>
+</ul>
+
+#### Associations
+<ul class="tsd-index-list" style="list-style: none">
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_associations_belongs_to_many_d_.html">BelongsToMany</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_associations_belongs_to_many_d_.html">BelongsTo</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_associations_has_many_d_.html">HasMany</a></li>
+  <li class="tsd-kind-module"><a class="tsd-kind-icon" href="modules/_lib_associations_has_one_d_.html">HasOne</a></li>
+</ul>
+
+## Example
+
+_User.ts_
+
+```ts
+import {
+  Model,
+  FindOptions,
+  STRING,
+  BelongsTo,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  BelongsToCreateAssociationMixin
+} from 'sequelize';
+import {sequelize} from '../connection';
+
+export class User extends Model {
+
+  static associations: {
+    group: BelongsTo
+  };
+
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  // mixins for association (optional)
+  groupId: number;
+  group: UserGroup;
+  getGroup: BelongsToGetAssociationMixin<UserGroup>;
+  setGroup: BelongsToSetAssociationMixin<UserGroup, number>;
+  createGroup: BelongsToCreateAssociationMixin<UserGroup>;
+}
+
+User.init({
+  username: STRING,
+  firstName: STRING,
+  lastName: STRING
+}, {}, sequelize.modelManager);
+
+// associate
+// it is important to import _after_ the model above is already exported so the circular reference works.
+import {UserGroup} from './UserGroup';
+User.belongsTo(UserGroup, {as: 'group', foreignKey: 'groupId'});
+```
+
+_app.ts_
+
+```ts
+import {User, Group} from './models/User';
+
+async function test() {
+
+  const user = await User.findOne({include: [Group]}) as User;
+  user.firstName = 'John';
+  await user.save();
+  await user.setGroup(2);
+
+  new User();
+  new User({firstName: 'John'});
+
+  const user2 = await User.create({firstName: 'John', groupId: 1}) as User;
+}
+```

--- a/4/lib/data-types.d.ts
+++ b/4/lib/data-types.d.ts
@@ -41,6 +41,9 @@
  * ```
  */
 
+/**
+ *
+ */
 export type DataType = string | AbstractDataTypeStatic | AbstractDataType;
 
 export const ABSTRACT: AbstractDataTypeStatic;
@@ -92,7 +95,6 @@ export interface StringDataTypeOptions {
  *
  * Available properties: `BINARY`
  *
- * @property CHAR
  */
 export const CHAR: CharDataTypeStatic;
 
@@ -111,7 +113,6 @@ export interface CharDataTypeOptions extends StringDataTypeOptions {}
 
 /**
  * An (un)limited length text column. Available lengths: `tiny`, `medium`, `long`
- * @property TEXT
  */
 export const TEXT: TextDataTypeStatic;
 
@@ -161,7 +162,6 @@ export interface NumberDataTypeOptions {
  *
  * Available properties: `UNSIGNED`, `ZEROFILL`
  *
- * @property INTEGER
  */
 export const INTEGER: IntegerDataTypeStatic;
 
@@ -183,7 +183,6 @@ export interface IntegerDataTypeOptions {
  *
  * Available properties: `UNSIGNED`, `ZEROFILL`
  *
- * @property BIGINT
  */
 export const BIGINT: BigIntDataTypeStatic;
 
@@ -202,10 +201,6 @@ export interface BigIntDataTypeOptions {
 
 /**
  * Floating point number (4-byte precision). Accepts one or two arguments for precision
- *
- * Available properties: `UNSIGNED`, `ZEROFILL`
- *
- * @property FLOAT
  */
  export const FLOAT: FloatDataTypeStatic;
 
@@ -228,10 +223,6 @@ export interface BigIntDataTypeOptions {
 
  /**
   * Floating point number (4-byte precision). Accepts one or two arguments for precision
-  *
-  * Available properties: `UNSIGNED`, `ZEROFILL`
-  *
-  * @property REAL
   */
 export const REAL: RealDataTypeStatic;
 
@@ -254,10 +245,6 @@ export interface RealDataTypeOptions {
 
 /**
  * Floating point number (8-byte precision). Accepts one or two arguments for precision
- *
- * Available properties: `UNSIGNED`, `ZEROFILL`
- *
- * @property DOUBLE
  */
 export const DOUBLE: DoubleDataTypeStatic;
 
@@ -279,10 +266,6 @@ export interface DoubleDataTypeOptions {
 
 /**
  * Decimal number. Accepts one or two arguments for precision
- *
- * Available properties: `UNSIGNED`, `ZEROFILL`
- *
- * @property DECIMAL
  */
 export const DECIMAL: DecimalDataTypeStatic;
 
@@ -306,19 +289,16 @@ export interface DecimalDataTypeOptions {
 
 /**
  * A boolean / tinyint column, depending on dialect
- * @property BOOLEAN
  */
 export const BOOLEAN: AbstractDataTypeStatic;
 
 /**
  * A time column
- * @property TIME
  */
 export const TIME: AbstractDataTypeStatic;
 
 /**
  * A datetime column
- * @property DATE
  */
 export const DATE: DateDataTypeStatic;
 
@@ -339,7 +319,6 @@ export interface DateDataTypeOptions {
 
 /**
  * A date only column
- * @property DATEONLY
  */
 export const DATEONLY: DateOnlyDataTypeStatic;
 
@@ -360,32 +339,26 @@ export interface DateOnlyDataTypeOptions {
 
 /**
  * A key / value column. Only available in postgres.
- * @property HSTORE
  */
 export const HSTORE: AbstractDataTypeStatic;
 
 /**
  * A JSON string column. Only available in postgres.
- * @property JSON
  */
 export const JSON: AbstractDataTypeStatic;
 
 /**
  * A pre-processed JSON data column. Only available in postgres.
- * @property JSONB
  */
 export const JSONB: AbstractDataTypeStatic;
 
 /**
  * A default value of the current timestamp
- * @property NOW
  */
 export const NOW: AbstractDataTypeStatic;
 
 /**
  * Binary storage. Available lengths: `tiny`, `medium`, `long`
- *
- * @property BLOB
  */
 export const BLOB: BlobDataTypeStatic;
 
@@ -409,8 +382,8 @@ export interface BlobDataTypeOptions {
 /**
  * Range types are data types representing a range of values of some element type (called the range's subtype).
  * Only available in postgres.
- * See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
- * @property RANGE
+ *
+ * See [Postgres documentation](http://www.postgresql.org/docs/9.4/static/rangetypes.html) for more details
  */
 export const RANGE: RangeDataTypeStatic;
 
@@ -434,19 +407,16 @@ export interface RangeDataTypeOptions<T extends RangeableDataType> {
 
 /**
  * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
- * @property UUID
  */
 export const UUID: AbstractDataTypeStatic;
 
 /**
  * A default unique universal identifier generated following the UUID v1 standard
- * @property UUIDV1
  */
 export const UUIDV1: AbstractDataTypeStatic;
 
 /**
  * A default unique universal identifier generated following the UUID v4 standard
- * @property UUIDV4
  */
 export const UUIDV4: AbstractDataTypeStatic;
 
@@ -489,7 +459,6 @@ export const UUIDV4: AbstractDataTypeStatic;
  * ```
  *
  * In the above code the password is stored plainly in the password field so it can be validated, but is never stored in the DB.
- * @property VIRTUAL
  * @alias NONE
  */
 export const VIRTUAL: VirtualDataTypeStatic;
@@ -506,8 +475,6 @@ export interface VirtualDataType<T extends AbstractDataTypeStatic|AbstractDataTy
 
 /**
  * An enumeration. `DataTypes.ENUM('value', 'another value')`.
- *
- * @property ENUM
  */
 export const ENUM: EnumDataTypeStatic;
 
@@ -529,7 +496,6 @@ export interface EnumDataTypeOptions<T extends string> {
 
 /**
  * An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
- * @property ARRAY
  */
 export const ARRAY: ArrayDataTypeStatic;
 
@@ -551,7 +517,6 @@ export interface ArrayDataTypeOptions<T extends AbstractDataTypeStatic|AbstractD
 
 /**
  * A geometry datatype represents two dimensional spacial objects.
- * @property GEOMETRY
  */
 export const GEOMETRY: GeometryDataTypeStatic;
 
@@ -600,37 +565,3 @@ export interface GeographyDataTypeOptions {
 
 export const NONE: typeof VIRTUAL;
 // export ['DOUBLE PRECISION']: typeof DOUBLE;
-
-export interface DataTypes {
-  ABSTRACT: typeof ABSTRACT;
-  STRING: typeof STRING;
-  CHAR: typeof CHAR;
-  TEXT: typeof TEXT;
-  NUMBER: typeof NUMBER;
-  INTEGER: typeof INTEGER;
-  BIGINT: typeof BIGINT;
-  FLOAT: typeof FLOAT;
-  REAL: typeof REAL;
-  DOUBLE: typeof DOUBLE;
-  DECIMAL: typeof DECIMAL;
-  BOOLEAN: typeof BOOLEAN;
-  TIME: typeof TIME;
-  DATE: typeof DATE;
-  DATEONLY: typeof DATEONLY;
-  HSTORE: typeof HSTORE;
-  JSON: typeof JSON;
-  JSONB: typeof JSONB;
-  NOW: typeof NOW;
-  BLOB: typeof BLOB;
-  RANGE: typeof RANGE;
-  UUID: typeof UUID;
-  UUIDV1: typeof UUIDV1;
-  UUIDV4: typeof UUIDV4;
-  VIRTUAL: typeof VIRTUAL;
-  ENUM: typeof ENUM;
-  ARRAY: typeof ARRAY;
-  GEOMETRY: typeof GEOMETRY;
-  GEOGRAPHY: typeof GEOGRAPHY;
-  'DOUBLE PRECISION': typeof DOUBLE;
-}
-export const DataTypes: DataTypes;

--- a/4/lib/deferrable.d.ts
+++ b/4/lib/deferrable.d.ts
@@ -1,69 +1,6 @@
 
-export interface AbstractDeferrableStatic {
-  new (): AbstractDeferrable;
-  (): AbstractDeferrable;
-}
-export interface AbstractDeferrable {
-  toString(): string;
-  toSql(): string;
-}
-
-export interface InitiallyDeferredDeferrableStatic extends AbstractDeferrableStatic {
-  new (): InitiallyDeferredDeferrable;
-  (): InitiallyDeferredDeferrable;
-}
-export interface InitiallyDeferredDeferrable extends AbstractDeferrable {}
-export const INITIALLY_DEFERRED: InitiallyDeferredDeferrableStatic;
-
-export interface InitiallyImmediateDeferrableStatic extends AbstractDeferrableStatic {
-  new (): InitiallyImmediateDeferrable;
-  (): InitiallyImmediateDeferrable;
-}
-export interface InitiallyImmediateDeferrable extends AbstractDeferrable {}
-export const INITIALLY_IMMEDIATE: InitiallyImmediateDeferrableStatic;
-
-
 /**
- * Will set the constraints to not deferred. This is the default in PostgreSQL and it make
- * it impossible to dynamically defer the constraints within a transaction.
- */
-export interface NotDeferrableStatic extends AbstractDeferrableStatic {
-  new (): NotDeferrable;
-  (): NotDeferrable;
-}
-export interface NotDeferrable {}
-export const NOT: NotDeferrableStatic;
-
-
-/**
- * Will trigger an additional query at the beginning of a
- * transaction which sets the constraints to deferred.
- *
- * @param constraints An array of constraint names. Will defer all constraints by default.
- */
-export interface SetDeferredDeferrableStatic extends AbstractDeferrableStatic {
-  new (constraints: string[]): SetDeferredDeferrable;
-  (constraints: string[]): SetDeferredDeferrable;
-}
-export interface SetDeferredDeferrable {}
-export const SET_DEFERRED: SetDeferredDeferrableStatic;
-
-
-/**
- * Will trigger an additional query at the beginning of a
- * transaction which sets the constraints to immediately.
- *
- * @param constraints An array of constraint names. Will defer all constraints by default.
- */
-export interface SetImmediateDeferrableStatic extends AbstractDeferrableStatic {
-  new (constraints: string[]): SetImmediateDeferrable;
-  (constraints: string[]): SetImmediateDeferrable;
-}
-export interface SetImmediateDeferrable {}
-export const SET_IMMEDIATE: SetImmediateDeferrableStatic;
-
-/**
- * A collection of properties related to deferrable constraints. It can be used to
+ * Can be used to
  * make foreign key constraints deferrable and to set the constaints within a
  * transaction. This is only supported in PostgreSQL.
  *
@@ -93,10 +30,79 @@ export const SET_IMMEDIATE: SetImmediateDeferrableStatic;
  * });
  * ```
  */
-export const Deferrable: {
-  INITIALLY_DEFERRED: InitiallyDeferredDeferrableStatic;
-  INITIALLY_IMMEDIATE: InitiallyImmediateDeferrableStatic;
-  NOT: NotDeferrableStatic;
-  SET_DEFERRED: SetDeferredDeferrableStatic;
-  SET_IMMEDIATE: SetImmediateDeferrableStatic;
+
+/**
+ *
+ */
+export interface AbstractDeferrableStatic {
+  new (): AbstractDeferrable;
+  (): AbstractDeferrable;
 }
+export interface AbstractDeferrable {
+  toString(): string;
+  toSql(): string;
+}
+
+export interface InitiallyDeferredDeferrableStatic extends AbstractDeferrableStatic {
+  new (): InitiallyDeferredDeferrable;
+  (): InitiallyDeferredDeferrable;
+}
+export interface InitiallyDeferredDeferrable extends AbstractDeferrable {}
+export const INITIALLY_DEFERRED: InitiallyDeferredDeferrableStatic;
+
+export interface InitiallyImmediateDeferrableStatic extends AbstractDeferrableStatic {
+  new (): InitiallyImmediateDeferrable;
+  (): InitiallyImmediateDeferrable;
+}
+export interface InitiallyImmediateDeferrable extends AbstractDeferrable {}
+export const INITIALLY_IMMEDIATE: InitiallyImmediateDeferrableStatic;
+
+
+export interface NotDeferrableStatic extends AbstractDeferrableStatic {
+  new (): NotDeferrable;
+  (): NotDeferrable;
+}
+export interface NotDeferrable {}
+/**
+ * Will set the constraints to not deferred. This is the default in PostgreSQL and it make
+ * it impossible to dynamically defer the constraints within a transaction.
+ */
+export const NOT: NotDeferrableStatic;
+
+
+export interface SetDeferredDeferrableStatic extends AbstractDeferrableStatic {
+  /**
+   * @param constraints An array of constraint names. Will defer all constraints by default.
+   */
+  new (constraints: string[]): SetDeferredDeferrable;
+  /**
+   * @param constraints An array of constraint names. Will defer all constraints by default.
+   */
+  (constraints: string[]): SetDeferredDeferrable;
+}
+export interface SetDeferredDeferrable {}
+/**
+ * Will trigger an additional query at the beginning of a
+ * transaction which sets the constraints to deferred.
+ */
+export const SET_DEFERRED: SetDeferredDeferrableStatic;
+
+
+export interface SetImmediateDeferrableStatic extends AbstractDeferrableStatic {
+  /**
+   * @param constraints An array of constraint names. Will defer all constraints by default.
+   */
+  new (constraints: string[]): SetImmediateDeferrable;
+  /**
+   * @param constraints An array of constraint names. Will defer all constraints by default.
+   */
+  (constraints: string[]): SetImmediateDeferrable;
+}
+export interface SetImmediateDeferrable {}
+/**
+ * Will trigger an additional query at the beginning of a
+ * transaction which sets the constraints to immediately.
+ *
+ * @param constraints An array of constraint names. Will defer all constraints by default.
+ */
+export const SET_IMMEDIATE: SetImmediateDeferrableStatic;

--- a/4/lib/sequelize.d.ts
+++ b/4/lib/sequelize.d.ts
@@ -3,7 +3,7 @@ import {DataType} from './data-types';
 import {Literal, Json, Where, Col, Cast, Fn} from './utils';
 import {Transaction, TransactionOptions} from './transaction';
 import {QueryInterface, QueryOptions} from './query-interface';
-import {DataTypes} from './data-types';
+import * as DataTypes from './data-types';
 import {Promise} from './promise';
 import {ModelManager} from './model-manager';
 import {
@@ -1067,7 +1067,7 @@ export class Sequelize {
    */
   import<T extends typeof Model>(
     path: string,
-    defineFunction?: (sequelize: Sequelize, dataTypes: DataTypes) => T
+    defineFunction?: (sequelize: Sequelize, dataTypes: typeof DataTypes) => T
   ): T;
 
   /**
@@ -1267,7 +1267,8 @@ export * from './associations/index';
 export * from './errors';
 export {BaseError as Error} from './errors';
 export {useInflection} from './utils';
-export {Deferrable} from './deferrable';
+import * as Deferrable from './deferrable';
+export {Deferrable};
 export {Promise} from './promise';
 export {Validator} from './utils/validator-extras';
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,5 @@
 
 Typescript Typings for [Sequelize](http://sequelizejs.com).
 
-## Versions
-
-- [3](3/)
-- [4](4/)
+## [API Documentation v3](http://typed-sequelize.surge.sh/v3)
+## [API Documentation v4](http://typed-sequelize.surge.sh/v3)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 Typescript Typings for [Sequelize](http://sequelizejs.com).
 
 ## [API Documentation v3](http://typed-sequelize.surge.sh/v3)
-## [API Documentation v4](http://typed-sequelize.surge.sh/v3)
+## [API Documentation v4](http://typed-sequelize.surge.sh/v4)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "tslint": "^3.14.0",
+    "typedoc": "^0.4.4",
     "typescript": "^1.8.10",
     "typings": "^1.3.2"
   },
@@ -20,7 +21,10 @@
     "build": "npm run build-v3 && npm run build-v4",
     "test": "npm run test-v3 && npm run build-v4",
     "build+test": "npm run build+test-v3 && npm run build+test-v4",
-    "lint": "tslint -c tslint.json 3/**/*.ts 4/**/*.ts"
+    "lint": "tslint -c tslint.json 3/**/*.ts 4/**/*.ts",
+    "typedoc-v3": "typedoc --module es6 --target es6 --includeDeclarations --excludeExternals --readme 3/docs_index.md --name \"TypeScript definitions for Sequelize v3\" --mode file --out typedoc/v3 3/index.d.ts 3/lib/data-types.d.ts 3/typings/index.d.ts",
+    "typedoc-v4": "typedoc --module es6 --target es6 --includeDeclarations --excludeExternals --readme 4/docs_index.md --name \"TypeScript definitions for Sequelize v4\" --mode modules --out typedoc/v4 4/lib/sequelize.d.ts 4/lib/model.d.ts 4/lib/transaction.d.ts 4/lib/errors.d.ts 4/lib/data-types.d.ts 4/lib/query-interface.d.ts 4/lib/deferrable.d.ts 4/lib/associations/base.d.ts 4/lib/associations/belongs-to-many.d.ts 4/lib/associations/belongs-to.d.ts 4/lib/associations/has-many.d.ts 4/lib/associations/has-one.d.ts 4/typings/index.d.ts",
+    "typedoc": "npm run typedoc-v3 && npm run typedoc-v4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Let's face it: These typings are extremely complicated and the real Sequelize docs are incredibly bad. One reason for this are the extreme amount of nested options available. TypeScript has the unique ability to define these as interfaces, which makes it perfect for documentation.

In the generated docs you can actually click on the types of options to get to their interfaces and it is 100% searchable.

 - http://typed-sequelize.surge.sh/v3
 - http://typed-sequelize.surge.sh/v4

The docs are automatically build in CI and deployed to surge