### PR TITLE
Missing `beforeCount` signature

### DIFF
--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2319,7 +2319,7 @@ declare module sequelize {
      * @param fn   A callback function that is called with options
      */
     beforeCount(name: string, fn: (options: CountOptions, fn?: Function) => void): void;
-    beforeCount(fn: (options: CountOptions) => void): void;
+    beforeCount(fn: (options: CountOptions, fn?: Function) => void): void;
   
     /**
      * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2075,6 +2075,7 @@ declare module sequelize {
     beforeBulkUpdate?: (options: UpdateOptions, fn?: Function) => any;
     afterBulkUpdate?: (options: UpdateOptions, fn?: Function) => any;
     beforeFind?: (options: FindOptions, fn?: Function) => any;
+    beforeCount?: (options: FindOptions, fn?: Function) => any;
     beforeFindAfterExpandIncludeAll?: (options: FindOptions, fn?: Function) => any;
     beforeFindAfterOptions?: (options: FindOptions, fn?: Function) => any;
     afterFind?: (instancesOrInstance: Array<TInstance> | TInstance, options: FindOptions,
@@ -2311,6 +2312,13 @@ declare module sequelize {
     beforeFind(name: string, fn: (options: FindOptions, fn?: Function) => void): void;
     beforeFind(fn: (options: FindOptions, fn?: Function) => void): void;
 
+    /**
+     * A hook that is run before a count query
+     *
+     * @param fn   A callback function that is called with options
+     */
+    static beforeCount(fn: (options: FindOptions) => void): void;
+  
     /**
      * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
      *

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2317,7 +2317,7 @@ declare module sequelize {
      *
      * @param fn   A callback function that is called with options
      */
-    static beforeCount(fn: (options: FindOptions) => void): void;
+    beforeCount(fn: (options: FindOptions) => void): void;
   
     /**
      * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2075,7 +2075,7 @@ declare module sequelize {
     beforeBulkUpdate?: (options: UpdateOptions, fn?: Function) => any;
     afterBulkUpdate?: (options: UpdateOptions, fn?: Function) => any;
     beforeFind?: (options: FindOptions, fn?: Function) => any;
-    beforeCount?: (options: FindOptions, fn?: Function) => any;
+    beforeCount?: (options: CountOptions, fn?: Function) => any;
     beforeFindAfterExpandIncludeAll?: (options: FindOptions, fn?: Function) => any;
     beforeFindAfterOptions?: (options: FindOptions, fn?: Function) => any;
     afterFind?: (instancesOrInstance: Array<TInstance> | TInstance, options: FindOptions,

--- a/3/index.d.ts
+++ b/3/index.d.ts
@@ -2315,9 +2315,11 @@ declare module sequelize {
     /**
      * A hook that is run before a count query
      *
+     * @param name
      * @param fn   A callback function that is called with options
      */
-    beforeCount(fn: (options: FindOptions) => void): void;
+    beforeCount(name: string, fn: (options: CountOptions, fn?: Function) => void): void;
+    beforeCount(fn: (options: CountOptions) => void): void;
   
     /**
      * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1409,7 +1409,7 @@ export interface HooksOptions {
   beforeBulkUpdate?: (options: UpdateOptions) => any;
   afterBulkUpdate?: (options: UpdateOptions) => any;
   beforeFind?: (options: FindOptions) => any;
-  beforeCount?: (options: FindOptions) => any;
+  beforeCount?: (options: CountOptions) => any;
   beforeFindAfterExpandIncludeAll?: (options: FindOptions) => any;
   beforeFindAfterOptions?: (options: FindOptions) => any;
   afterFind?: (instancesOrInstance: Array<Model> | Model, options: FindOptions) => any;

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1409,6 +1409,7 @@ export interface HooksOptions {
   beforeBulkUpdate?: (options: UpdateOptions) => any;
   afterBulkUpdate?: (options: UpdateOptions) => any;
   beforeFind?: (options: FindOptions) => any;
+  beforeCount?: (options: FindOptions) => any;
   beforeFindAfterExpandIncludeAll?: (options: FindOptions) => any;
   beforeFindAfterOptions?: (options: FindOptions) => any;
   afterFind?: (instancesOrInstance: Array<Model> | Model, options: FindOptions) => any;
@@ -2180,6 +2181,13 @@ export abstract class Model {
    */
   static beforeFind(name: string, fn: (options: FindOptions) => void): void;
   static beforeFind(fn: (options: FindOptions) => void): void;
+
+  /**
+   * A hook that is run before a count query
+   *
+   * @param fn   A callback function that is called with options
+   */
+  static beforeCount(fn: (options: FindOptions) => void): void;
 
   /**
    * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -2188,7 +2188,7 @@ export abstract class Model {
    * @param name
    * @param fn   A callback function that is called with options
    */
-  static beforeCount(name: string, fn: (options: CountOptions, fn?: Function) => void): void;
+  static beforeCount(name: string, fn: (options: CountOptions) => void): void;
   static beforeCount(fn: (options: CountOptions) => void): void;
 
   /**

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -2185,9 +2185,11 @@ export abstract class Model {
   /**
    * A hook that is run before a count query
    *
+   * @param name
    * @param fn   A callback function that is called with options
    */
-  static beforeCount(fn: (options: FindOptions) => void): void;
+  static beforeCount(name: string, fn: (options: CountOptions, fn?: Function) => void): void;
+  static beforeCount(fn: (options: CountOptions) => void): void;
 
   /**
    * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded


### PR DESCRIPTION
This adds the signature for `beforeCount` hooks.

I hope it's safe to use `FindOptions` as the type for the options parameter, just like it's done for `beforeFind`.

**Edit:** also added to v3.