### PR TITLE
Added correct typing for has one create mixin values.

### DIFF
--- a/lib/associations/has-one.d.ts
+++ b/lib/associations/has-one.d.ts
@@ -107,7 +107,7 @@ export interface HasOneCreateAssociationMixinOptions extends HasOneSetAssociatio
  * @see http://docs.sequelizejs.com/en/latest/api/associations/has-one/
  * @see Instance
  */
-export type HasOneCreateAssociationMixin<TModel> = (
-    values?: { [attribute: string]: any },
+export type HasOneCreateAssociationMixin<TModel extends Model> = (
+    values?: TModel["_creationAttributes"],
     options?: HasOneCreateAssociationMixinOptions
 ) => Promise<TModel>


### PR DESCRIPTION
Hello everyone!
I'm trying to make a wrapper around sequelize mixins and I stumbled upon this.
If I understood the mixing correctly, the `createModel` mixin for `hasOne` association does not seem to have the correct typing for the creation values (accessible from Model["_creationAttributes"]).

Do these changes make sense ?

If yes, I can replicate them to all other association types.